### PR TITLE
expose getScreenImage

### DIFF
--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -472,6 +472,30 @@ NAN_METHOD(getScreenSize)
 	NanReturnValue(obj);
 }
 
+NAN_METHOD(getScreenImage)
+{
+	NanScope();
+
+	size_t x = args[0]->Int32Value();
+	size_t y = args[1]->Int32Value();
+	size_t w = args[2]->Int32Value();
+	size_t h = args[3]->Int32Value();
+	MMBitmapRef bitmap = copyMMBitmapFromDisplayInRect(MMRectMake(x, y, w, h));
+	uint32_t bufferSize = bitmap->bytesPerPixel * bitmap->width * bitmap->height;
+	Local<Object> buffer = NanNewBufferHandle((char*)bitmap->imageBuffer, bufferSize);
+
+	Local<Object> obj = NanNew<Object>();
+	obj->Set(NanNew<String>("width"), NanNew<Number>(bitmap->width));
+	obj->Set(NanNew<String>("height"), NanNew<Number>(bitmap->height));
+	obj->Set(NanNew<String>("byteWidth"), NanNew<Number>(bitmap->bytewidth));
+	obj->Set(NanNew<String>("bitsPerPixel"), NanNew<Number>(bitmap->bitsPerPixel));
+	obj->Set(NanNew<String>("bytesPerPixel"), NanNew<Number>(bitmap->bytesPerPixel));
+	obj->Set(NanNew<String>("image"), buffer);
+
+	destroyMMBitmap(bitmap);
+	NanReturnValue(obj);
+}
+
 void init(Handle<Object> target) 
 {
 
@@ -492,7 +516,7 @@ void init(Handle<Object> target)
 
 	target->Set(NanNew<String>("keyTap"),
 		NanNew<FunctionTemplate>(keyTap)->GetFunction());
-	
+
 	target->Set(NanNew<String>("keyToggle"),
 		NanNew<FunctionTemplate>(keyToggle)->GetFunction());
 
@@ -504,6 +528,9 @@ void init(Handle<Object> target)
 
 	target->Set(NanNew<String>("getScreenSize"),
 		NanNew<FunctionTemplate>(getScreenSize)->GetFunction());
+
+	target->Set(NanNew<String>("getScreenImage"),
+		NanNew<FunctionTemplate>(getScreenImage)->GetFunction());
 
 }
 


### PR DESCRIPTION
I'm not sure if this is correct, but it seems to work.  I'm very new to C/C++ stuff.

On a 300ms interval at 2560x1440 the memory usage goes from 20mb to 250mb and back down again.

It might be significantly faster if I can reuse buffers. Also, it's returning a SlowBuffer in 0.10, and the docs advise against using SlowBuffer for large data.

```
# 150ms interval, measure `robot.getScreenImage(0, 0, 2560, 1440);` with process.hrtime
Execution time (hr): 0s 97.8387ms
Execution time (hr): 0s 70.431239ms
Execution time (hr): 0s 70.394325ms
Execution time (hr): 0s 79.024596ms
Execution time (hr): 0s 96.242392ms
Execution time (hr): 0s 78.415336ms
Execution time (hr): 0s 73.583015ms
Execution time (hr): 0s 73.15636ms
Execution time (hr): 0s 77.463437ms
Execution time (hr): 0s 75.860151ms
Execution time (hr): 0s 129.808632ms
Execution time (hr): 0s 125.236072ms
Execution time (hr): 0s 127.089746ms
Execution time (hr): 0s 97.068304ms
Execution time (hr): 0s 87.929368ms
Execution time (hr): 0s 130.232699ms
Execution time (hr): 0s 135.494717ms
Execution time (hr): 0s 101.097455ms
Execution time (hr): 0s 85.203419ms
Execution time (hr): 0s 86.463413ms
Execution time (hr): 0s 116.454051ms
Execution time (hr): 0s 72.302956ms
Execution time (hr): 0s 64.864825ms
Execution time (hr): 0s 66.089723ms
Execution time (hr): 0s 77.848504ms
Execution time (hr): 0s 70.759078ms
Execution time (hr): 0s 75.107431ms
Execution time (hr): 0s 68.109502ms
Execution time (hr): 0s 70.178252ms
Execution time (hr): 0s 65.27376ms
Execution time (hr): 0s 100.983102ms
Average execution time (hr): 2s 88.58079225806452ms
```