### PR TITLE
Fix README Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Get pixel color under the mouse.
 var robot = require("robotjs");
 
 //Get mouse position. 
-var mouse=robot.getMousePos();
+var mouse = robot.getMousePos();
 
 //Get pixel color in hex format. 
 var hex = robot.getPixelColor(mouse.x, mouse.y);


### PR DESCRIPTION
Add spaces around assignment operator on line 54 to match the formatting of all other assignment operators in examples in README.