### PR TITLE
io.js v3.0.0 is not supported, so it's allowed to fail. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ language: node_js
 node_js:
   - 0.10
   - 0.12
-  - iojs
+  - iojs-v2
+  - iojs-v3
+
+matrix:
+  allow_failures:
+    - node_js: iojs-v3
 
 addons:
   apt:


### PR DESCRIPTION
nan has been updated to v2.0.0 to include support for io.js v3, but it requires significant code changes. This change allows io.js v3 builds to fail until I can update nan.

#71 related. 