### PR TITLE
Allow up or down for keyToggle.

### DIFF
--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -517,7 +517,7 @@ NAN_METHOD(keyToggle)
 		}
 		else
 		{
-			return Nan::ThrowError("Invalid mouse button state specified.");
+			return Nan::ThrowError("Invalid key state specified.");
 		}
 	}
 

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -482,9 +482,9 @@ NAN_METHOD(keyToggle)
 	bool down;
 	char *k;
 	char *f;
+	Nan::Utf8String kstr(info[0]);
+	Nan::Utf8String fstr(info[2]);
 
-	v8::String::Utf8Value kstr(info[0]->ToString());
-	v8::String::Utf8Value fstr(info[2]->ToString());
 	k = *kstr;
 	f = *fstr;
 

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -482,12 +482,16 @@ NAN_METHOD(keyToggle)
 	bool down;
 	char *k;
 	char *f;
+	
+	//Get arguments from JavaScript.
 	Nan::Utf8String kstr(info[0]);
 	Nan::Utf8String fstr(info[2]);
 
+	//Convert arguments to chars.
 	k = *kstr;
 	f = *fstr;
-
+	
+	//Check and confirm number of arguments.
 	switch (info.Length())
 	{
     	case 3:
@@ -521,6 +525,7 @@ NAN_METHOD(keyToggle)
 		}
 	}
 
+	//Get key modifier.
 	if (f)
 	{
 		switch(CheckKeyFlags(f, &flags))
@@ -534,6 +539,7 @@ NAN_METHOD(keyToggle)
 		}
 	}
 
+	//Get the acutal key.
 	switch(CheckKeyCodes(k, &key))
 	{
 		case -1:

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -479,8 +479,8 @@ NAN_METHOD(keyToggle)
 	MMKeyFlags flags = MOD_NONE;
 	MMKeyCode key;
 
-	char *k;
 	bool down;
+	char *k;
 	char *f;
 
 	v8::String::Utf8Value kstr(info[0]->ToString());

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -485,7 +485,6 @@ NAN_METHOD(keyToggle)
 
 	v8::String::Utf8Value kstr(info[0]->ToString());
 	v8::String::Utf8Value fstr(info[2]->ToString());
-	down = info[1]->BooleanValue();
 	k = *kstr;
 	f = *fstr;
 
@@ -498,6 +497,28 @@ NAN_METHOD(keyToggle)
       		break;
     	default:
       		return Nan::ThrowError("Invalid number of arguments.");
+	}
+	
+	//Get down value if provided.
+	if (info.Length() > 1)
+	{
+		char *d;
+
+		Nan::Utf8String dstr(info[1]);
+		d = *dstr;
+
+		if (strcmp(d, "down") == 0)
+		{
+			down = true;
+		}
+		else if (strcmp(d, "up") == 0)
+		{
+			down = false;
+		}
+		else
+		{
+			return Nan::ThrowError("Invalid mouse button state specified.");
+		}
 	}
 
 	if (f)


### PR DESCRIPTION
Instead of 0 or 1 for the second argument, allow “up” or “down”. This is more user friendly and matches mouseToggle.

This change breaks backwards compatibility, but before 1.0.0 this is alright. 

Closes #101.