### PR TITLE
Added dragMouse function

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -18,6 +18,44 @@
 	#define M_SQRT2 1.4142135623730950488016887 /* Fix for MSVC. */
 #endif
 
+/* Some convenience macros for converting our enums to the system API types. */
+#if defined(IS_MACOSX)
+
+#define MMMouseToCGEventType(down, button) \
+	(down ? MMMouseDownToCGEventType(button) : MMMouseUpToCGEventType(button))
+
+#define MMMouseDownToCGEventType(button) \
+	((button) == (LEFT_BUTTON) ? kCGEventLeftMouseDown \
+	                       : ((button) == RIGHT_BUTTON ? kCGEventRightMouseDown \
+	                                                   : kCGEventOtherMouseDown))
+
+#define MMMouseUpToCGEventType(button) \
+	((button) == LEFT_BUTTON ? kCGEventLeftMouseUp \
+	                         : ((button) == RIGHT_BUTTON ? kCGEventRightMouseUp \
+	                                                     : kCGEventOtherMouseUp))
+
+#define MMMouseDragToCGEventType(button) \
+	((button) == LEFT_BUTTON ? kCGEventLeftMouseDragged \
+	                         : ((button) == RIGHT_BUTTON ? kCGEventRightMouseDragged \
+	                                                     : kCGEventOtherMouseDragged))
+
+#elif defined(IS_WINDOWS)
+
+#define MMMouseToMEventF(down, button) \
+	(down ? MMMouseDownToMEventF(button) : MMMouseUpToMEventF(button))
+
+#define MMMouseUpToMEventF(button) \
+	((button) == LEFT_BUTTON ? MOUSEEVENTF_LEFTUP \
+	                         : ((button) == RIGHT_BUTTON ? MOUSEEVENTF_RIGHTUP \
+	                                                     : MOUSEEVENTF_MIDDLEUP))
+
+#define MMMouseDownToMEventF(button) \
+	((button) == LEFT_BUTTON ? MOUSEEVENTF_LEFTDOWN \
+	                         : ((button) == RIGHT_BUTTON ? MOUSEEVENTF_RIGHTDOWN \
+	                                                     : MOUSEEVENTF_MIDDLEDOWN))
+
+#endif
+
 /**
  * Move the mouse to a specific point.
  * @param point The coordinates to move the mouse to (x, y).
@@ -41,6 +79,20 @@ void moveMouse(MMPoint point)
 	point.y = MOUSE_COORD_TO_ABS(point.y, GetSystemMetrics(SM_CYSCREEN));
 	mouse_event(MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE,
 	            (DWORD)point.x, (DWORD)point.y, 0, 0);
+#endif
+}
+
+void dragMouse(MMPoint point, const MMMouseButton button)
+{
+#if defined(IS_MACOSX)
+	const CGEventType dragType = MMMouseDragToCGEventType(button);
+	const CGEventRef drag = CGEventCreateMouseEvent(NULL, dragType,
+	                                                CGPointFromMMPoint(point),
+	                                                (CGMouseButton)button);
+	CGEventPost(kCGSessionEventTap, drag);
+	CFRelease(drag);
+#else
+	moveMouse(point);
 #endif
 }
 
@@ -70,39 +122,6 @@ MMPoint getMousePos()
 	return MMPointFromPOINT(point);
 #endif
 }
-
-/* Some convenience macros for converting our enums to the system API types. */
-#if defined(IS_MACOSX)
-
-#define MMMouseToCGEventType(down, button) \
-	(down ? MMMouseDownToCGEventType(button) : MMMouseUpToCGEventType(button))
-
-#define MMMouseDownToCGEventType(button) \
-	((button) == (LEFT_BUTTON) ? kCGEventLeftMouseDown \
-	                       : ((button) == RIGHT_BUTTON ? kCGEventRightMouseDown \
-	                                                   : kCGEventOtherMouseDown))
-
-#define MMMouseUpToCGEventType(button) \
-	((button) == LEFT_BUTTON ? kCGEventLeftMouseUp \
-	                         : ((button) == RIGHT_BUTTON ? kCGEventRightMouseUp \
-	                                                     : kCGEventOtherMouseUp))
-
-#elif defined(IS_WINDOWS)
-
-#define MMMouseToMEventF(down, button) \
-	(down ? MMMouseDownToMEventF(button) : MMMouseUpToMEventF(button))
-
-#define MMMouseUpToMEventF(button) \
-	((button) == LEFT_BUTTON ? MOUSEEVENTF_LEFTUP \
-	                         : ((button) == RIGHT_BUTTON ? MOUSEEVENTF_RIGHTUP \
-	                                                     : MOUSEEVENTF_MIDDLEUP))
-
-#define MMMouseDownToMEventF(button) \
-	((button) == LEFT_BUTTON ? MOUSEEVENTF_LEFTDOWN \
-	                         : ((button) == RIGHT_BUTTON ? MOUSEEVENTF_RIGHTDOWN \
-	                                                     : MOUSEEVENTF_MIDDLEDOWN))
-
-#endif
 
 /**
  * Press down a button, or release it.

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -62,6 +62,12 @@ typedef int MMMouseWheelDirection;
  * screen boundaries. */
 void moveMouse(MMPoint point);
 
+/* Like moveMouse, moves the mouse to the given point on-screen, but marks
+ * the event as the mouse being dragged on platforms where it is supported.
+ * It is up to the caller to ensure that this point is within the screen
+ * boundaries. */
+void dragMouse(MMPoint point, const MMMouseButton button);
+
 /* Smoothly moves the mouse from the current position to the given point.
  * deadbeef_srand() should be called before using this function.
  *

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -26,7 +26,66 @@ int keyboardDelay = 10;
 
 */
 
-NAN_METHOD(moveMouse) 
+int CheckMouseButton(const char * const b, MMMouseButton * const button)
+{
+	if (!button) return -1;
+
+	if (strcmp(b, "left") == 0)
+	{
+		*button = LEFT_BUTTON;
+	}
+	else if (strcmp(b, "right") == 0)
+	{
+		*button = RIGHT_BUTTON;
+	}
+	else if (strcmp(b, "middle") == 0)
+	{
+		*button = CENTER_BUTTON;
+	}
+	else
+	{
+		return -2;
+	}
+
+	return 0;
+}
+
+NAN_METHOD(dragMouse)
+{
+	if (info.Length() < 2)
+	{
+		return Nan::ThrowError("Invalid number of arguments.");
+	}
+
+	const size_t x = info[0]->Int32Value();
+	const size_t y = info[1]->Int32Value();
+	MMMouseButton button = LEFT_BUTTON;
+
+	if (info.Length() >= 3)
+	{
+		Nan::Utf8String bstr(info[2]);
+		const char * const b = *bstr;
+
+		switch (CheckMouseButton(b, &button))
+		{
+			case -1:
+				return Nan::ThrowError("Null pointer in mouse button code.");
+				break;
+			case -2:
+				return Nan::ThrowError("Invalid mouse button specified.");
+				break;
+		}
+	}
+
+	MMPoint point;
+	point = MMPointMake(x, y);
+	dragMouse(point, button);
+	microsleep(mouseDelay);
+
+	info.GetReturnValue().Set(Nan::New(1));
+}
+
+NAN_METHOD(moveMouse)
 {
 	if (info.Length() < 2)
 	{
@@ -78,26 +137,17 @@ NAN_METHOD(mouseClick)
 
 	if (info.Length() > 0)
 	{
-		char *b;
-
 		v8::String::Utf8Value bstr(info[0]->ToString());
-		b = *bstr;
+		const char * const b = *bstr;
 
-		if (strcmp(b, "left") == 0)
+		switch (CheckMouseButton(b, &button))
 		{
-			button = LEFT_BUTTON;
-		}
-		else if (strcmp(b, "right") == 0)
-		{
-			button = RIGHT_BUTTON;
-		}
-		else if (strcmp(b, "middle") == 0)
-		{
-			button = CENTER_BUTTON;
-		}
-		else
-		{
-			return Nan::ThrowError("Invalid mouse button specified.");
+			case -1:
+				return Nan::ThrowError("Null pointer in mouse button code.");
+				break;
+			case -2:
+				return Nan::ThrowError("Invalid mouse button specified.");
+				break;
 		}
 	}
 
@@ -152,26 +202,17 @@ NAN_METHOD(mouseToggle)
 
 	if (info.Length() == 2)
 	{
-		char *b;
-
 		Nan::Utf8String bstr(info[1]);
-		b = *bstr;
+		const char * const b = *bstr;
 
-		if (strcmp(b, "left") == 0)
+		switch (CheckMouseButton(b, &button))
 		{
-			button = LEFT_BUTTON;
-		}
-		else if (strcmp(b, "right") == 0)
-		{
-			button = RIGHT_BUTTON;
-		}
-		else if (strcmp(b, "middle") == 0)
-		{
-			button = CENTER_BUTTON;
-		}
-		else
-		{
-			return Nan::ThrowError("Invalid mouse button specified.");
+			case -1:
+				return Nan::ThrowError("Null pointer in mouse button code.");
+				break;
+			case -2:
+				return Nan::ThrowError("Invalid mouse button specified.");
+				break;
 		}
 	}
 	else if (info.Length() > 2)
@@ -628,6 +669,8 @@ NAN_METHOD(getScreenSize)
 
 NAN_MODULE_INIT(InitAll)
 {
+    Nan::Set(target, Nan::New("dragMouse").ToLocalChecked(),
+        Nan::GetFunction(Nan::New<FunctionTemplate>(dragMouse)).ToLocalChecked());
 
     Nan::Set(target, Nan::New("moveMouse").ToLocalChecked(),
         Nan::GetFunction(Nan::New<FunctionTemplate>(moveMouse)).ToLocalChecked());


### PR DESCRIPTION
This adds a new dragMouse function that allows you to do things like:

```
robot.moveMouse(300, 300);
robot.mouseToggle('down');
robot.dragMouse(400, 300);
robot.mouseToggle('up');
```

It just calls moveMouse for platforms other than OS X.

Resolves #127. 