### PR TITLE
Prevent unused variable warning for Mac and Linux.

### DIFF
--- a/src/keypress.c
+++ b/src/keypress.c
@@ -69,9 +69,13 @@ void tapKeyCode(MMKeyCode code, MMKeyFlags flags)
 }
 
 void toggleKey(char c, const bool down, MMKeyFlags flags)
-{
-	int modifiers;
+{	
 	MMKeyCode keyCode = keyCodeForChar(c);
+	
+	//Prevent unused variable warning for Mac and Linux.
+#if defined(IS_WINDOWS)
+	int modifiers;
+#endif	
 	
 	if (isupper(c) && !(flags & MOD_SHIFT)) {
 		flags |= MOD_SHIFT; /* Not sure if this is safe for all layouts. */


### PR DESCRIPTION
This fixes a warning introduced in d99f3bb8264f6925ac0da2356c55f33f84388e79. 

```
> robotjs@0.3.4 install /private/var/tmp/robot/node_modules/robotjs
> node-gyp rebuild

  CXX(target) Release/obj.target/robotjs/src/robotjs.o
  CC(target) Release/obj.target/robotjs/src/deadbeef_rand.o
  CC(target) Release/obj.target/robotjs/src/mouse.o
  CC(target) Release/obj.target/robotjs/src/keypress.o
../src/keypress.c:73:6: warning: unused variable 'modifiers' [-Wunused-variable]
        int modifiers;
            ^
1 warning generated.
  CC(target) Release/obj.target/robotjs/src/keycode.o
  CC(target) Release/obj.target/robotjs/src/screen.o
  CC(target) Release/obj.target/robotjs/src/screengrab.o
  CC(target) Release/obj.target/robotjs/src/snprintf.o
  CC(target) Release/obj.target/robotjs/src/MMBitmap.o
  SOLINK_MODULE(target) Release/robotjs.node
robotjs@0.3.4 node_modules/robotjs
└── nan@2.1.0
```