### PR TITLE
Screen capture fix

### DIFF
--- a/src/MMBitmap.c
+++ b/src/MMBitmap.c
@@ -34,6 +34,14 @@ void destroyMMBitmap(MMBitmapRef bitmap)
 	free(bitmap);
 }
 
+void destroyMMBitmapBuffer(char * bitmapBuffer, void * hint)
+{
+	if (bitmapBuffer != NULL)	
+	{
+		free(bitmapBuffer);
+	}
+}
+
 MMBitmapRef copyMMBitmap(MMBitmapRef bitmap)
 {
 	uint8_t *copiedBuf = NULL;

--- a/src/MMBitmap.h
+++ b/src/MMBitmap.h
@@ -34,6 +34,9 @@ MMBitmapRef createMMBitmap(uint8_t *buffer, size_t width, size_t height,
 /* Releases memory occupied by MMBitmap. */
 void destroyMMBitmap(MMBitmapRef bitmap);
 
+/* Releases memory occupied by MMBitmap. Acts via CallBack method*/
+void destroyMMBitmapBuffer(char * bitmapBuffer, void * hint);
+
 /* Returns copy of MMBitmap, to be destroy()'d by caller. */
 MMBitmapRef copyMMBitmap(MMBitmapRef bitmap);
 

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -700,7 +700,7 @@ NAN_METHOD(captureScreen)
 	MMBitmapRef bitmap = copyMMBitmapFromDisplayInRect(MMRectMake(0, 0, displaySize.width, displaySize.height));
 	
 	uint32_t bufferSize = bitmap->bytesPerPixel * bitmap->width * bitmap->height;
-	Local<Object> buffer = Nan::NewBuffer((char*)bitmap->imageBuffer, bufferSize).ToLocalChecked();
+	Local<Object> buffer = Nan::NewBuffer((char*)bitmap->imageBuffer, bufferSize, destroyMMBitmapBuffer, NULL).ToLocalChecked();
 
 	Local<Object> obj = Nan::New<Object>();
 	Nan::Set(obj, Nan::New("width").ToLocalChecked(), Nan::New<Number>(bitmap->width));
@@ -709,8 +709,6 @@ NAN_METHOD(captureScreen)
 	Nan::Set(obj, Nan::New("bitsPerPixel").ToLocalChecked(), Nan::New<Number>(bitmap->bitsPerPixel));
 	Nan::Set(obj, Nan::New("bytesPerPixel").ToLocalChecked(), Nan::New<Number>(bitmap->bytesPerPixel));
 	Nan::Set(obj, Nan::New("image").ToLocalChecked(), buffer);
-
-	destroyMMBitmap(bitmap);
 	
 	info.GetReturnValue().Set(obj);
 }


### PR DESCRIPTION
This should fix the Screen Capture bug. 
Unfortunately I seem to have messed up the branch a bit so I cannot merge. (Need to learn Git properly)
The changes in the ```Screen Caputre Fix``` should fix it.
The problem was the memory was being de-allocated even though the ownership of the memory was transferred to the Buffer object. By adding the callback, which will be called when the object is Garbage collected, there wont be any memory leaks.