### PR TITLE
Map virtual key before triggering keybd_event

### DIFF
--- a/src/keypress.h
+++ b/src/keypress.h
@@ -51,6 +51,11 @@ extern "C"
 
 #endif
 
+#if defined(IS_WINDOWS)
+/* Send win32 key event for given key. */
+void win32KeyEvent(int key, MMKeyFlags flags);
+#endif
+
 /* Toggles the given key down or up. */
 void toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags);
 


### PR DESCRIPTION
I'm using RobotJS to simulate keyboard input into an RDP session. However, because the Windows RDP client listens for scan codes instead of the key codes (for security reasons?), simulating key events with RobotJS doesn't work. See [this thread on SO](https://stackoverflow.com/questions/345147/how-to-simulate-keybard-input-to-a-remote-desktop-session#345302).

This PR adds the correct scancode using [MapVirtualKey](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646306(v=vs.85).aspx). With this change, RobotJS can send key events locally and through an RDP session. Tested on Windows Server 2012 and Windows 10.

Cheers,
Mike