### PR TITLE
fix for #97, mouseScroll Windows XP

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -195,8 +195,14 @@ void doubleClick(MMMouseButton button)
  * This uses the magnitude to scroll the required amount in the direction. 
  * TODO Requires further fine tuning based on the requirements.
  */
-void scrollMouse(int scrollMagnitude, MMMouseWheelDirection scrollDirection)	
+void scrollMouse(int scrollMagnitude, MMMouseWheelDirection scrollDirection)
 {
+	#if defined(IS_WINDOWS)
+		// Fix for #97 https://github.com/octalmage/robotjs/issues/97,
+		// C89 needs variables declared on top of functions (mouseScrollInput)
+		INPUT mouseScrollInput;
+	#endif
+
 	/* Direction should only be considered based on the scrollDirection. This
 	 * Should not interfere. */
 	int cleanScrollMagnitude = abs(scrollMagnitude);
@@ -204,41 +210,40 @@ void scrollMouse(int scrollMagnitude, MMMouseWheelDirection scrollDirection)
 	{
 		return;
 	}
-	
+
 	/* Set up the OS specific solution */
 	#if defined(__APPLE__)
-	
+
 		CGWheelCount wheel = 1;
 		CGEventRef event;
-	
+
 		/* Make scroll magnitude negative if we're scrolling down. */
 		cleanScrollMagnitude = cleanScrollMagnitude * scrollDirection;
-		
+
 		event = CGEventCreateScrollWheelEvent(NULL, kCGScrollEventUnitLine, wheel, cleanScrollMagnitude, 0);
 		CGEventPost(kCGHIDEventTap, event);
-		
+
 	#elif defined(USE_X11)
 
 		int x;
 		int dir = 4; /* Button 4 is up, 5 is down. */
 		Display *display = XGetMainDisplay();
-		
+
 		if (scrollDirection == DIRECTION_DOWN)
 		{
 			dir = 5;
 		}
-	
+
 		for (x = 0; x < cleanScrollMagnitude; x++)
 		{
 			XTestFakeButtonEvent(display, dir, 1, CurrentTime);
 			XTestFakeButtonEvent(display, dir, 0, CurrentTime);
 		}
-		
+
 		XFlush(display);
-		
+
 	#elif defined(IS_WINDOWS)
-		//FIXME: Need to figure out why this code doesn't work on Windows XP.
-		/*INPUT mouseScrollInput;
+
 		mouseScrollInput.type = INPUT_MOUSE;
 		mouseScrollInput.mi.dx = 0;
 		mouseScrollInput.mi.dy = 0;
@@ -246,7 +251,9 @@ void scrollMouse(int scrollMagnitude, MMMouseWheelDirection scrollDirection)
 		mouseScrollInput.mi.time = 0;
 		mouseScrollInput.mi.dwExtraInfo = 0;
 		mouseScrollInput.mi.mouseData = WHEEL_DELTA * scrollDirection * cleanScrollMagnitude;
-		SendInput(1, &mouseScrollInput, sizeof(mouseScrollInput));*/
+
+		SendInput(1, &mouseScrollInput, sizeof(mouseScrollInput));
+
 	#endif
 }
 


### PR DESCRIPTION
Fix mouse scroll on Windows XP, see [#97](https://github.com/octalmage/robotjs/issues/97).

C89 (2008 redistributables (XP)) requires variable declarations to be on top of a block. Newer versions have better support for C99, which is more flexible in this.

Tested with 2008 redistributables on Windows 10.