### PR TITLE
Modified the mouseToggle method signature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export function setMouseDelay(delay: number) : void
 export function moveMouse(x: number, y: number) : void
 export function moveMouseSmooth(x: number, y: number) : void
 export function mouseClick(button?: string, double?: boolean) : void
-export function mouseToggle(down?: string, button?: boolean) : void 
+export function mouseToggle(down?: string, button?: string) : void
 export function dragMouse(x: number, y: number) : void
 export function scrollMouse(magnitude: number, direction: string) : void
 export function getMousePos(): { x: number, y: number }


### PR DESCRIPTION
according to the documentation the button parameter should be string and not boolean:
mouseToggle([down], [button])
Toggles mouse button.

Arguments

Argument	Description	Default
down	Accepts down or up.	down
button	Accepts left, right, or middle.	left