### PR TITLE
Support Unicode Characters for .typeString()

### DIFF
--- a/src/keypress.c
+++ b/src/keypress.c
@@ -227,7 +227,11 @@ static void tapUniKey(char c)
 
 void typeString(const char *str)
 {
-	uint c, c1, c2, c3, n;
+	unsigned long c;
+	unsigned long c1;
+	unsigned long c2;
+	unsigned long c3;
+	unsigned long n;
 
 	while (*str != '\0') {
 		c = *str++;
@@ -254,8 +258,14 @@ void typeString(const char *str)
 			n = ((c & 0x07) << 18) | (c1 << 12) | (c2 << 6) | c3;
 		}
 
+		#if defined(IS_MACOSX)
 		toggleUnicodeKey(n, true);
 		toggleUnicodeKey(n, false);
+		#else
+		toggleUniKey(n, true);
+		toggleUniKey(n, false);
+		#endif
+
 	}
 }
 


### PR DESCRIPTION
Here's is preliminary patch for support unicode characters in robotjs for `.typeString()`.

```js
robot.typeString('Àçćéñtéd'); // works
robot.typeString('你好吗？'); // works
robot.typeString('😆💩🌺😍👍😠🐠😝😢🤣😢🦑'); // works
```

This fixes #16 #30

It has does simple UTF-8 parsing (without validation) and I have tested this with Chinese and accented characters [edit: and emjios] on MacOS.

~~However, I have not figured how to have emojis sending yet nor have I have tested it on other platforms although I've tried to make the code changes minimal here.~~