### PR TITLE
Link in readme to docs goes straight to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a work in progress so the exported functions could change at any time be
 
 - [Installation](#installation)
 - [Examples](#examples)
-- [API](https://github.com/octalmage/robotjs/wiki/Syntax)
+- [API](https://http://robotjs.io/docs/syntax)
 - [Building](#building)
 - [Plans](#plans)
 - [Progress](#progress)

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ console.log("#" + hex + " at x:" + mouse.x + " y:" + mouse.y);
 ```
 Read the [Wiki](https://github.com/octalmage/robotjs/wiki) for more information!
 
-## [API](https://github.com/octalmage/robotjs/wiki/Syntax)
+## [API](http://robotjs.io/docs/syntax)
 
-The [RobotJS API](https://github.com/octalmage/robotjs/wiki/Syntax) is contained in the [Wiki](https://github.com/octalmage/robotjs/wiki).
+The RobotJS API is hosted at <https://robotjs.io/docs/syntax>.
 
 ## Building
 


### PR DESCRIPTION
Current behaviour takes you to the old docs which contain a link to the website.