### PR TITLE
keyToggle and keyTap not working on MacOS when the current language is non-Latin

### DIFF
--- a/src/keycode.c
+++ b/src/keycode.c
@@ -134,7 +134,7 @@ MMKeyCode keyCodeForChar(const char c)
 
 CFStringRef createStringForKey(CGKeyCode keyCode)
 {
-	TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardInputSource();
+	TISInputSourceRef currentKeyboard = TISCopyCurrentASCIICapableKeyboardInputSource();
 	CFDataRef layoutData =
 		TISGetInputSourceProperty(currentKeyboard,
 		                          kTISPropertyUnicodeKeyLayoutData);


### PR DESCRIPTION
keyToggle and keyTap are working only with ASCII chars. 

The dictionary with chars and the key codes is generated using the current language and if this chars are not ASCII we won't be able to find the corresponding key code that we need for executing keyToggle. This will result in not printing any chars.

With this patch, no matter of the current language the dictionary will be constructed only from ASCII chars. This fixes the issue.
