### PR TITLE
Multi monitor support for mouseMove and dragMouse

### DIFF
--- a/src/mouse.c
+++ b/src/mouse.c
@@ -62,7 +62,7 @@
  * @param event The mouse move event (by ref).
  * @param point The new mouse x and y.
  */
-void calculateDeltas(CGEventRef *event, MMPoint point)
+void calculateDeltas(CGEventRef *event, MMSignedPoint point)
 {
 	/**
 	 * The next few lines are a workaround for games not detecting mouse moves.
@@ -88,11 +88,11 @@ void calculateDeltas(CGEventRef *event, MMPoint point)
  * Move the mouse to a specific point.
  * @param point The coordinates to move the mouse to (x, y).
  */
-void moveMouse(MMPoint point)
+void moveMouse(MMSignedPoint point)
 {
 #if defined(IS_MACOSX)
 	CGEventRef move = CGEventCreateMouseEvent(NULL, kCGEventMouseMoved,
-	                                          CGPointFromMMPoint(point),
+	                                          CGPointFromMMSignedPoint(point),
 	                                          kCGMouseButtonLeft);
 
 	calculateDeltas(&move, point);
@@ -122,12 +122,12 @@ void moveMouse(MMPoint point)
 #endif
 }
 
-void dragMouse(MMPoint point, const MMMouseButton button)
+void dragMouse(MMSignedPoint point, const MMMouseButton button)
 {
 #if defined(IS_MACOSX)
 	const CGEventType dragType = MMMouseDragToCGEventType(button);
 	CGEventRef drag = CGEventCreateMouseEvent(NULL, dragType,
-	                                                CGPointFromMMPoint(point),
+	                                                CGPointFromMMSignedPoint(point),
 	                                                (CGMouseButton)button);
 	calculateDeltas(&drag, point);
 
@@ -355,7 +355,7 @@ bool smoothlyMoveMouse(MMPoint endPoint)
 			return false;
 		}
 
-		moveMouse(pos);
+		moveMouse(MMSignedPointMake((int32_t)pos.x, (int32_t)pos.y));
 
 		/* Wait 1 - 3 milliseconds. */
 		microsleep(DEADBEEF_UNIFORM(1.0, 3.0));

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -11,7 +11,7 @@
 	#include <stdbool.h>
 #endif
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 {
 #endif
 #if defined(IS_MACOSX)
@@ -49,7 +49,7 @@ extern "C"
 #define MMMouseButtonIsValid(button) \
 	(button == LEFT_BUTTON || button == RIGHT_BUTTON || \
 	 button == CENTER_BUTTON)
-	 
+
 enum __MMMouseWheelDirection
 {
 	DIRECTION_DOWN 	= -1,
@@ -60,13 +60,13 @@ typedef int MMMouseWheelDirection;
 /* Immediately moves the mouse to the given point on-screen.
  * It is up to the caller to ensure that this point is within the
  * screen boundaries. */
-void moveMouse(MMPoint point);
+void moveMouse(MMSignedPoint point);
 
 /* Like moveMouse, moves the mouse to the given point on-screen, but marks
  * the event as the mouse being dragged on platforms where it is supported.
  * It is up to the caller to ensure that this point is within the screen
  * boundaries. */
-void dragMouse(MMPoint point, const MMMouseButton button);
+void dragMouse(MMSignedPoint point, const MMMouseButton button);
 
 /* Smoothly moves the mouse from the current position to the given point.
  * deadbeef_srand() should be called before using this function.
@@ -88,7 +88,7 @@ void clickMouse(MMMouseButton button);
 /* Double clicks the mouse with the given button. */
 void doubleClick(MMMouseButton button);
 
-/* Scrolls the mouse in the stated direction. 
+/* Scrolls the mouse in the stated direction.
  * TODO: Add a smoothly scroll mouse next. */
 void scrollMouse(int x, int y);
 

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -60,8 +60,8 @@ NAN_METHOD(dragMouse)
 		return Nan::ThrowError("Invalid number of arguments.");
 	}
 
-	const size_t x = info[0]->Int32Value();
-	const size_t y = info[1]->Int32Value();
+	const int32_t x = info[0]->Int32Value();
+	const int32_t y = info[1]->Int32Value();
 	MMMouseButton button = LEFT_BUTTON;
 
 	if (info.Length() == 3)
@@ -80,8 +80,8 @@ NAN_METHOD(dragMouse)
 		}
 	}
 
-	MMPoint point;
-	point = MMPointMake(x, y);
+	MMSignedPoint point;
+	point = MMSignedPointMake(x, y);
 	dragMouse(point, button);
 	microsleep(mouseDelay);
 
@@ -94,11 +94,11 @@ NAN_METHOD(moveMouse)
 	{
 		return Nan::ThrowError("Invalid number of arguments.");
 	}
-	size_t x = info[0]->Int32Value();
-	size_t y = info[1]->Int32Value();
+	int32_t x = info[0]->Int32Value();
+	int32_t y = info[1]->Int32Value();
 
-	MMPoint point;
-	point = MMPointMake(x, y);
+	MMSignedPoint point;
+	point = MMSignedPointMake(x, y);
 	moveMouse(point);
 	microsleep(mouseDelay);
 
@@ -247,7 +247,7 @@ NAN_METHOD(scrollMouse)
 	{
     	return Nan::ThrowError("Invalid number of arguments.");
 	}
-	
+
 	int x = info[0]->Int32Value();
 	int y = info[1]->Int32Value();
 

--- a/src/types.h
+++ b/src/types.h
@@ -5,6 +5,7 @@
 #include "os.h"
 #include "inline_keywords.h" /* For H_INLINE */
 #include <stddef.h>
+#include <stdint.h>
 
 /* Some generic, cross-platform types. */
 
@@ -14,6 +15,14 @@ struct _MMPoint {
 };
 
 typedef struct _MMPoint MMPoint;
+
+
+struct _MMSignedPoint {
+	int32_t x;
+	int32_t y;
+};
+
+typedef struct _MMSignedPoint MMSignedPoint;
 
 struct _MMSize {
 	size_t width;
@@ -32,6 +41,14 @@ typedef struct _MMRect MMRect;
 H_INLINE MMPoint MMPointMake(size_t x, size_t y)
 {
 	MMPoint point;
+	point.x = x;
+	point.y = y;
+	return point;
+}
+
+H_INLINE MMSignedPoint MMSignedPointMake(int32_t x, int32_t y)
+{
+	MMSignedPoint point;
 	point.x = x;
 	point.y = y;
 	return point;
@@ -59,6 +76,9 @@ H_INLINE MMRect MMRectMake(size_t x, size_t y, size_t width, size_t height)
 
 #define CGPointFromMMPoint(p) CGPointMake((CGFloat)(p).x, (CGFloat)(p).y)
 #define MMPointFromCGPoint(p) MMPointMake((size_t)(p).x, (size_t)(p).y)
+
+#define CGPointFromMMSignedPoint(p) CGPointMake((CGFloat)(p).x, (CGFloat)(p).y)
+#define MMSignedPointFromCGPoint(p) MMPointMake((int32_t)(p).x, (int32_t)(p).y)
 
 #elif defined(IS_WINDOWS)
 


### PR DESCRIPTION
If the user has more than 1 monitor the coordinates of a monitor can be negative. Before the PR all the parameters for mouseMove and dragMouse were using size_t which is unsigned. That's why it was not possible to pass negative coordinates and move the mouse to a monitor with negative coordinates.

Fix #88 