### PR TITLE
Align typeStringDelayed() functionality to typeString().

### DIFF
--- a/src/keypress.c
+++ b/src/keypress.c
@@ -234,13 +234,13 @@ static void tapUniKey(char c)
 	toggleUniKey(c, false);
 }
 
-void typeString(const char *str)
+static void typeStringWithDelay(const char *str, const double mspcDelay)
 {
+	unsigned long n;
 	unsigned short c;
 	unsigned short c1;
 	unsigned short c2;
 	unsigned short c3;
-	unsigned long n;
 
 	while (*str != '\0') {
 		c = *str++;
@@ -271,11 +271,18 @@ void typeString(const char *str)
 		toggleUnicodeKey(n, true);
 		toggleUnicodeKey(n, false);
 		#else
-		toggleUniKey(n, true);
-		toggleUniKey(n, false);
+		tapUniKey(n);
 		#endif
 
+		if (mspcDelay > 0) {
+			microsleep(mspcDelay + (DEADBEEF_UNIFORM(0.0, 62.5)));
+		}
 	}
+}
+
+void typeString(const char *str)
+{
+	typeStringWithDelay(str, 0);
 }
 
 void typeStringDelayed(const char *str, const unsigned cpm)
@@ -286,8 +293,5 @@ void typeStringDelayed(const char *str, const unsigned cpm)
 	/* Average milli-seconds per character */
 	const double mspc = (cps == 0.0) ? 0.0 : 1000.0 / cps;
 
-	while (*str != '\0') {
-		tapUniKey(*str++);
-		microsleep(mspc + (DEADBEEF_UNIFORM(0.0, 62.5)));
-	}
+	typeStringWithDelay(str, mspc);
 }

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -569,28 +569,36 @@ NAN_METHOD(keyToggle)
 
 NAN_METHOD(typeString)
 {
-	char *str;
-	Nan::Utf8String string(info[0]);
+	if (info.Length() > 0) {
+		char *str;
+		Nan::Utf8String string(info[0]);
 
-	str = *string;
+		str = *string;
 
-	typeString(str);
+		typeString(str);
 
-	info.GetReturnValue().Set(Nan::New(1));
+		info.GetReturnValue().Set(Nan::New(1));
+	} else {
+		return Nan::ThrowError("Invalid number of arguments.");
+	}
 }
 
 NAN_METHOD(typeStringDelayed)
 {
-	char *str;
-	Nan::Utf8String string(info[0]);
+	if (info.Length() > 0) {
+		char *str;
+		Nan::Utf8String string(info[0]);
 
-	str = *string;
+		str = *string;
 
-	size_t cpm = info[1]->Int32Value();
+		size_t cpm = info[1]->Int32Value();
 
-	typeStringDelayed(str, cpm);
+		typeStringDelayed(str, cpm);
 
-	info.GetReturnValue().Set(Nan::New(1));
+		info.GetReturnValue().Set(Nan::New(1));
+	} else {
+		return Nan::ThrowError("Invalid number of arguments.");
+	}
 }
 
 NAN_METHOD(setKeyboardDelay)

--- a/test/keyboard.js
+++ b/test/keyboard.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var robot = require('..');
 var os = require('os');
 
-//TODO: Need tests for keyToggle, typeString, typeStringDelayed, and setKeyboardDelay.
+// TODO: Need tests for setKeyboardDelay.
 
 test('Tap a key.', function(t)
 {
@@ -56,4 +56,71 @@ test('Tap all numpad keys.', function(t)
 	}
 
 	t.end();
+});
+
+test('Test Key Toggle.', function(t)
+{
+	t.plan(4);
+
+	t.ok(robot.keyToggle("a", "down") === 1, 'Successfully pressed a.');
+	t.ok(robot.keyToggle("a", "up") === 1, 'Successfully released a.');
+
+	t.throws(function()
+	{
+		t.ok(robot.keyToggle("ά", "down") === 1, 'Successfully pressed ά.');
+		t.ok(robot.keyToggle("ά", "up") === 1, 'Successfully released ά.');
+	}, /Invalid key code specified./, 'exception tapping ά.');
+
+	t.throws(function()
+	{
+		t.ok(robot.keyToggle("嗨", "down") === 1, 'Successfully pressed 嗨.');
+		t.ok(robot.keyToggle("嗨", "up") === 1, 'Successfully released 嗨.');
+	}, /Invalid key code specified./, 'exception tapping 嗨.');
+});
+
+test('Type Ctrl+Shift+RightArrow.', function(t)
+{
+	t.plan(2);
+
+	var modifiers = []
+    modifiers.push('shift')
+	modifiers.push('control')
+
+	t.ok(robot.keyToggle("right", "down", modifiers) === 1, 'Successfully pressed Ctrl+Shift+RightArrow.');
+	t.ok(robot.keyToggle("right", "up", modifiers) === 1, 'Successfully released Ctrl+Shift+RightArrow.');
+});
+
+test('Type a string.', function(t)
+{
+	if (os.platform() === 'darwin') {
+		t.plan(3);
+		t.ok(robot.typeString("rάöち嗨") === 1, 'successfully typed "rάöち嗨".');
+	} else {
+		t.plan(2);
+	}
+
+	t.ok(robot.typeString("Typed a string") === 1, 'successfully typed with delay "Typed a string".');
+
+	t.throws(function()
+	{
+		t.ok(robot.typeString() === 1, 'Successfully typed nothing.');
+	}, /Invalid number of arguments./, 'exception tapping nothing.');
+});
+
+test('Type a string with delay.', function(t)
+{
+	if (os.platform() === 'darwin') {
+		t.plan(3);
+		t.ok(robot.typeStringDelayed("rάöち嗨") === 1, 'successfully typed "rάöち嗨".');
+	} else {
+		t.plan(2);
+	}
+
+	// 10 characters per minute -> 3 seconds to write the whole sentence here.
+	t.ok(robot.typeStringDelayed("Typed a string with delay", 600) === 1, 'successfully typed with delay "Typed a string with delay".');
+
+	t.throws(function()
+	{
+		t.ok(robot.typeStringDelayed() === 1, 'Successfully typed nothing.');
+	}, /Invalid number of arguments./, 'exception tapping nothing.');
 });


### PR DESCRIPTION
 * Refactored a little bit to make typeStringDelayed() functionality identical to typeString().
 * Don't type the word "undefined" if typeString() or typeStringDelayed() is called with no arguments.
 * Tests added.

Closes #353