### PR TITLE
Unicode tap

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ export interface Screen {
 export function setKeyboardDelay(ms: number) : void
 export function keyTap(key: string, modifier?: string | string[]) : void
 export function keyToggle(key: string, down: string, modifier?: string | string[]) : void
+export function utf32Tap(utf32dec: number) : void
 export function typeString(string: string) : void
 export function typeStringDelayed(string: string, cpm: number) : void
 export function setMouseDelay(delay: number) : void

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export interface Screen {
 export function setKeyboardDelay(ms: number) : void
 export function keyTap(key: string, modifier?: string | string[]) : void
 export function keyToggle(key: string, down: string, modifier?: string | string[]) : void
-export function utf32Tap(utf32dec: number) : void
+export function unicodeTap(value: number) : void
 export function typeString(string: string) : void
 export function typeStringDelayed(string: string, cpm: number) : void
 export function setMouseDelay(delay: number) : void

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "typings": "index.d.ts",
   "scripts": {
     "test": "node test/all.js",
-    "install": "prebuild-install || node-gyp rebuild"
+    "test-keyboard": "node test/keyboard.js",
+    "install": "prebuild-install || node-gyp rebuild",
+    "install-debug": "prebuild-install || node-gyp rebuild --debug"
   },
   "repository": {
     "type": "git",
@@ -37,11 +39,11 @@
   },
   "homepage": "https://github.com/octalmage/robotjs",
   "dependencies": {
-    "nan": "^2.2.1",
-    "prebuild-install": "^2.1.1"
+    "nan": "^2.8.0",
+    "prebuild-install": "^2.4.1"
   },
   "devDependencies": {
-    "tape": "^3.5.0",
-    "prebuild": "v6.1.0"
+    "tape": "^4.8.0",
+    "prebuild": "v7.0.0"
   }
 }

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -211,10 +211,10 @@ void toggleUnicode(UniChar ch, const bool down)
 }
 #endif
 
-void tapUtf32(const unsigned utf32dec)
+void unicodeTap(const unsigned value)
 {
 	#if defined(IS_MACOSX)
-		UniChar ch = (UniChar)utf32dec; // Convert to unsigned char
+		UniChar ch = (UniChar)value; // Convert to unsigned char
 
 		toggleUnicode(ch, true);
 		toggleUnicode(ch, false);
@@ -224,7 +224,7 @@ void tapUtf32(const unsigned utf32dec)
 		// Set up a generic keyboard event.
 		ip.type = INPUT_KEYBOARD;
 		ip.ki.wVk = 0; // Virtual-key code
-		ip.ki.wScan = utf32dec; // Hardware scan code for key
+		ip.ki.wScan = value; // Hardware scan code for key
 		// ip.ki.wScan = 0x03B1;
 		ip.ki.time = 0; // System will provide its own time stamp.
 		ip.ki.dwExtraInfo = 0; // No extra info. Use the GetMessageExtraInfo function to obtain this information if needed.
@@ -273,7 +273,7 @@ void typeStringDelayed(const char *str, const unsigned cpm)
 			n = ((c & 0x07) << 18) | (c1 << 12) | (c2 << 6) | c3;
 		}
 
-		tapUtf32(n);
+		unicodeTap(n);
 
 		if (mspc > 0) {
 			microsleep(mspc + (DEADBEEF_UNIFORM(0.0, 62.5)));

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -225,7 +225,6 @@ void unicodeTap(const unsigned value)
 		ip.type = INPUT_KEYBOARD;
 		ip.ki.wVk = 0; // Virtual-key code
 		ip.ki.wScan = value; // Hardware scan code for key
-		// ip.ki.wScan = 0x03B1;
 		ip.ki.time = 0; // System will provide its own time stamp.
 		ip.ki.dwExtraInfo = 0; // No extra info. Use the GetMessageExtraInfo function to obtain this information if needed.
 		ip.ki.dwFlags = KEYEVENTF_UNICODE; // KEYEVENTF_KEYUP for key release.

--- a/src/keypress.h
+++ b/src/keypress.h
@@ -66,8 +66,8 @@ void tapKeyCode(MMKeyCode code, MMKeyFlags flags);
 void toggleKey(char c, const bool down, MMKeyFlags flags);
 void tapKey(char c, MMKeyFlags flags);
 
-/* Sends a UTF-32 character without modifiers. */
-void tapUtf32(const unsigned utf32dec);
+/* Sends a Unicode character without modifiers. */
+void unicodeTap(const unsigned value);
 
 /* Sends a UTF-8 string without modifiers. */
 void typeString(const char *str);

--- a/src/keypress.h
+++ b/src/keypress.h
@@ -69,15 +69,12 @@ void tapKey(char c, MMKeyFlags flags);
 /* Sends a Unicode character without modifiers. */
 void unicodeTap(const unsigned value);
 
-/* Sends a UTF-8 string without modifiers. */
-void typeString(const char *str);
-
 /* Macro to convert WPM to CPM integers.
  * (the average English word length is 5.1 characters.) */
 #define WPM_TO_CPM(WPM) (unsigned)(5.1 * WPM)
 
-/* Sends a string with partially random delays between each letter. Note that
- * deadbeef_srand() must be called before this function if you actually want
+/* Sends a UTF-8 string without modifiers and with partially random delays between each letter.
+ * Note that deadbeef_srand() must be called before this function if you actually want
  * randomness. */
 void typeStringDelayed(const char *str, const unsigned cpm);
 

--- a/src/keypress.h
+++ b/src/keypress.h
@@ -66,6 +66,9 @@ void tapKeyCode(MMKeyCode code, MMKeyFlags flags);
 void toggleKey(char c, const bool down, MMKeyFlags flags);
 void tapKey(char c, MMKeyFlags flags);
 
+/* Sends a UTF-32 character without modifiers. */
+void tapUtf32(const unsigned utf32dec);
+
 /* Sends a UTF-8 string without modifiers. */
 void typeString(const char *str);
 

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -567,12 +567,12 @@ NAN_METHOD(keyToggle)
 	info.GetReturnValue().Set(Nan::New(1));
 }
 
-NAN_METHOD(utf32Tap)
+NAN_METHOD(unicodeTap)
 {
-	size_t utf32dec = info[0]->Int32Value();
+	size_t value = info[0]->Int32Value();
 
-	if (utf32dec != 0) {
-		tapUtf32(utf32dec);
+	if (value != 0) {
+		unicodeTap(value);
 
 		info.GetReturnValue().Set(Nan::New(1));
 	} else {
@@ -865,8 +865,8 @@ NAN_MODULE_INIT(InitAll)
 	Nan::Set(target, Nan::New("keyToggle").ToLocalChecked(),
 		Nan::GetFunction(Nan::New<FunctionTemplate>(keyToggle)).ToLocalChecked());
 
-	Nan::Set(target, Nan::New("utf32Tap").ToLocalChecked(),
-		Nan::GetFunction(Nan::New<FunctionTemplate>(utf32Tap)).ToLocalChecked());
+	Nan::Set(target, Nan::New("unicodeTap").ToLocalChecked(),
+		Nan::GetFunction(Nan::New<FunctionTemplate>(unicodeTap)).ToLocalChecked());
 
 	Nan::Set(target, Nan::New("typeString").ToLocalChecked(),
 		Nan::GetFunction(Nan::New<FunctionTemplate>(typeString)).ToLocalChecked());

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -550,7 +550,7 @@ NAN_METHOD(keyToggle)
 		}
 	}
 
-	//Get the acutal key.
+	//Get the actual key.
 	switch(CheckKeyCodes(k, &key))
 	{
 		case -1:
@@ -561,10 +561,23 @@ NAN_METHOD(keyToggle)
 			break;
 		default:
 			toggleKeyCode(key, down, flags);
-			  microsleep(keyboardDelay);
+			microsleep(keyboardDelay);
 	}
 
 	info.GetReturnValue().Set(Nan::New(1));
+}
+
+NAN_METHOD(utf32Tap)
+{
+	size_t utf32dec = info[0]->Int32Value();
+
+	if (utf32dec != 0) {
+		tapUtf32(utf32dec);
+
+		info.GetReturnValue().Set(Nan::New(1));
+	} else {
+		return Nan::ThrowError("Invalid character typed.");
+	}
 }
 
 NAN_METHOD(typeString)
@@ -843,6 +856,9 @@ NAN_MODULE_INIT(InitAll)
 
 	Nan::Set(target, Nan::New("keyToggle").ToLocalChecked(),
 		Nan::GetFunction(Nan::New<FunctionTemplate>(keyToggle)).ToLocalChecked());
+
+	Nan::Set(target, Nan::New("utf32Tap").ToLocalChecked(),
+		Nan::GetFunction(Nan::New<FunctionTemplate>(utf32Tap)).ToLocalChecked());
 
 	Nan::Set(target, Nan::New("typeString").ToLocalChecked(),
 		Nan::GetFunction(Nan::New<FunctionTemplate>(typeString)).ToLocalChecked());

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -582,28 +582,36 @@ NAN_METHOD(utf32Tap)
 
 NAN_METHOD(typeString)
 {
-	char *str;
-	Nan::Utf8String string(info[0]);
+	if (info.Length() > 0) {
+		char *str;
+		Nan::Utf8String string(info[0]);
 
-	str = *string;
+		str = *string;
 
-	typeString(str);
+		typeStringDelayed(str, 0);
 
-	info.GetReturnValue().Set(Nan::New(1));
+		info.GetReturnValue().Set(Nan::New(1));
+	} else {
+		return Nan::ThrowError("Invalid number of arguments.");
+	}
 }
 
 NAN_METHOD(typeStringDelayed)
 {
-	char *str;
-	Nan::Utf8String string(info[0]);
+	if (info.Length() > 0) {
+		char *str;
+		Nan::Utf8String string(info[0]);
 
-	str = *string;
+		str = *string;
 
-	size_t cpm = info[1]->Int32Value();
+		size_t cpm = info[1]->Int32Value();
 
-	typeStringDelayed(str, cpm);
+		typeStringDelayed(str, cpm);
 
-	info.GetReturnValue().Set(Nan::New(1));
+		info.GetReturnValue().Set(Nan::New(1));
+	} else {
+		return Nan::ThrowError("Invalid number of arguments.");
+	}
 }
 
 NAN_METHOD(setKeyboardDelay)

--- a/test/keyboard.js
+++ b/test/keyboard.js
@@ -6,8 +6,9 @@ var os = require('os');
 
 test('Tap a key.', function(t)
 {
-	t.plan(4);
+	t.plan(5);
 	t.ok(robot.keyTap("a") === 1, 'successfully tapped "a".');
+	t.ok(robot.keyTap("control") === 1, 'successfully tapped "ctrl".');
 	t.ok(robot.keyTap("a", "control") === 1, 'successfully tapped "ctrl+a".');
 
 	t.throws(function()
@@ -56,4 +57,19 @@ test('Tap all numpad keys.', function(t)
 	}
 
 	t.end();
+});
+
+test('Tap a UTF32 character.', function(t)
+{
+	t.plan(6);
+	t.ok(robot.utf32Tap("r".charCodeAt(0)) === 1, 'successfully tapped "r".');
+	t.ok(robot.utf32Tap("ά".charCodeAt(0)) === 1, 'successfully tapped "ά".');
+	t.ok(robot.utf32Tap("ö".charCodeAt(0)) === 1, 'successfully tapped "ö".');
+	t.ok(robot.utf32Tap("ち".charCodeAt(0)) === 1, 'successfully tapped "ち".');
+	t.ok(robot.utf32Tap("嗨".charCodeAt(0)) === 1, 'successfully tapped "嗨".');
+
+	t.throws(function()
+	{
+		robot.utf32Tap();
+	}, /Invalid character typed./, 'tap nothing.');
 });

--- a/test/keyboard.js
+++ b/test/keyboard.js
@@ -2,7 +2,7 @@ var test = require('tape');
 var robot = require('..');
 var os = require('os');
 
-//TODO: Need tests for keyToggle, typeString, typeStringDelayed, and setKeyboardDelay.
+// TODO: Need tests for setKeyboardDelay.
 
 test('Tap a key.', function(t)
 {
@@ -61,15 +61,72 @@ test('Tap all numpad keys.', function(t)
 
 test('Tap a UTF32 character.', function(t)
 {
-	t.plan(6);
+	t.plan(7);
 	t.ok(robot.utf32Tap("r".charCodeAt(0)) === 1, 'successfully tapped "r".');
 	t.ok(robot.utf32Tap("ά".charCodeAt(0)) === 1, 'successfully tapped "ά".');
 	t.ok(robot.utf32Tap("ö".charCodeAt(0)) === 1, 'successfully tapped "ö".');
 	t.ok(robot.utf32Tap("ち".charCodeAt(0)) === 1, 'successfully tapped "ち".');
 	t.ok(robot.utf32Tap("嗨".charCodeAt(0)) === 1, 'successfully tapped "嗨".');
+	t.ok(robot.utf32Tap("ఝ".charCodeAt(0)) === 1, 'successfully tapped "ఝ".');
 
 	t.throws(function()
 	{
 		robot.utf32Tap();
 	}, /Invalid character typed./, 'tap nothing.');
+});
+
+test('Test Key Toggle.', function(t)
+{
+	t.plan(4);
+
+	t.ok(robot.keyToggle("a", "down") === 1, 'Successfully pressed a.');
+	t.ok(robot.keyToggle("a", "up") === 1, 'Successfully released a.');
+
+	t.throws(function()
+	{
+		t.ok(robot.keyToggle("ά", "down") === 1, 'Successfully pressed ά.');
+		t.ok(robot.keyToggle("ά", "up") === 1, 'Successfully released ά.');
+	}, /Invalid key code specified./, 'exception tapping ά.');
+
+	t.throws(function()
+	{
+		t.ok(robot.keyToggle("嗨", "down") === 1, 'Successfully pressed 嗨.');
+		t.ok(robot.keyToggle("嗨", "up") === 1, 'Successfully released 嗨.');
+	}, /Invalid key code specified./, 'exception tapping 嗨.');
+});
+
+test('Type Ctrl+Shift+RightArrow.', function(t)
+{
+	t.plan(2);
+
+	var modifiers = []
+    modifiers.push('shift')
+	modifiers.push('control')
+
+	t.ok(robot.keyToggle("right", "down", modifiers) === 1, 'Successfully pressed Ctrl+Shift+RightArrow.');
+	t.ok(robot.keyToggle("right", "up", modifiers) === 1, 'Successfully released Ctrl+Shift+RightArrow.');
+});
+
+test('Type a string.', function(t)
+{
+	t.plan(2);
+	t.ok(robot.typeString("Typed rάöち嗨ఝ 1") === 1, 'successfully typed "Typed rάöち嗨ఝ 1".');
+
+	t.throws(function()
+	{
+		t.ok(robot.typeString() === 1, 'Successfully typed nothing.');
+	}, /Invalid number of arguments./, 'exception tapping nothing.');
+});
+
+test('Type a string with delay.', function(t)
+{
+	t.plan(2);
+
+	// 10 characters per minute -> 3 seconds to write the whole sentence here.
+	t.ok(robot.typeStringDelayed("Typed rάöち嗨ఝ with delay 1", 600) === 1, 'successfully typed with delay "Typed rάöち嗨ఝ with delay 1".');
+
+	t.throws(function()
+	{
+		t.ok(robot.typeStringDelayed() === 1, 'Successfully typed nothing.');
+	}, /Invalid number of arguments./, 'exception tapping nothing.');
 });

--- a/test/keyboard.js
+++ b/test/keyboard.js
@@ -59,19 +59,19 @@ test('Tap all numpad keys.', function(t)
 	t.end();
 });
 
-test('Tap a UTF32 character.', function(t)
+test('Tap a Unicode character.', function(t)
 {
 	t.plan(7);
-	t.ok(robot.utf32Tap("r".charCodeAt(0)) === 1, 'successfully tapped "r".');
-	t.ok(robot.utf32Tap("ά".charCodeAt(0)) === 1, 'successfully tapped "ά".');
-	t.ok(robot.utf32Tap("ö".charCodeAt(0)) === 1, 'successfully tapped "ö".');
-	t.ok(robot.utf32Tap("ち".charCodeAt(0)) === 1, 'successfully tapped "ち".');
-	t.ok(robot.utf32Tap("嗨".charCodeAt(0)) === 1, 'successfully tapped "嗨".');
-	t.ok(robot.utf32Tap("ఝ".charCodeAt(0)) === 1, 'successfully tapped "ఝ".');
+	t.ok(robot.unicodeTap("r".charCodeAt(0)) === 1, 'successfully tapped "r".');
+	t.ok(robot.unicodeTap("ά".charCodeAt(0)) === 1, 'successfully tapped "ά".');
+	t.ok(robot.unicodeTap("ö".charCodeAt(0)) === 1, 'successfully tapped "ö".');
+	t.ok(robot.unicodeTap("ち".charCodeAt(0)) === 1, 'successfully tapped "ち".');
+	t.ok(robot.unicodeTap("嗨".charCodeAt(0)) === 1, 'successfully tapped "嗨".');
+	t.ok(robot.unicodeTap("ఝ".charCodeAt(0)) === 1, 'successfully tapped "ఝ".');
 
 	t.throws(function()
 	{
-		robot.utf32Tap();
+		robot.unicodeTap();
 	}, /Invalid character typed./, 'tap nothing.');
 });
 


### PR DESCRIPTION
Tested on Windows and Mac.

* Added a new unicodeTap() method.
* Supported Unicode characters for typeString() as well.
* Aligned the functionality of typeString() and typeStringDelayed() methods.
* Unit tests are added.

Additional comments can be found on the separate commits of this request.

Closes #351, #353, #386, #502 