### PR TITLE
Fix error with mouse moving in Windows with multiple displays

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ export function keyToggle(key: string, down: string, modifier?: string | string[
 export function typeString(string: string) : void
 export function typeStringDelayed(string: string, cpm: number) : void
 export function setMouseDelay(delay: number) : void
+export function updateScreenMetrics() : void
 export function moveMouse(x: number, y: number) : void
 export function moveMouseSmooth(x: number, y: number) : void
 export function mouseClick(button?: string, double?: boolean) : void

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -41,6 +41,18 @@
 
 #elif defined(IS_WINDOWS)
 
+// The width of the virtual screen, in pixels.
+static int vscreenWidth = -1; // not initialized
+
+// The height of the virtual screen, in pixels.
+static int vscreenHeight = -1; // not initialized
+
+// The coordinates for the left side of the virtual screen.
+static int vscreenMinX = 0;
+
+// The coordinates for the top of the virtual screen.
+static int vscreenMinY = 0;
+
 #define MMMouseToMEventF(down, button) \
 	(down ? MMMouseDownToMEventF(button) : MMMouseUpToMEventF(button))
 
@@ -83,7 +95,15 @@ void calculateDeltas(CGEventRef *event, MMPoint point)
 }
 #endif
 
-
+void updateScreenMetrics()
+{
+	#if defined(IS_WINDOWS)
+		vscreenWidth = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+		vscreenHeight = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+		vscreenMinX = GetSystemMetrics(SM_XVIRTUALSCREEN);
+		vscreenMinY = GetSystemMetrics(SM_YVIRTUALSCREEN);
+	#endif
+}
 /**
  * Move the mouse to a specific point.
  * @param point The coordinates to move the mouse to (x, y).
@@ -105,20 +125,24 @@ void moveMouse(MMPoint point)
 	             0, 0, 0, 0, point.x, point.y);
 	XSync(display, false);
 #elif defined(IS_WINDOWS)
-	//Mouse motion is now done using SendInput with MOUSEINPUT. We use Absolute mouse positioning
-	#define MOUSE_COORD_TO_ABS(coord, width_or_height) (((65536 * coord) / width_or_height) + (coord < 0 ? -1 : 1))
-	point.x = MOUSE_COORD_TO_ABS(point.x, GetSystemMetrics(SM_CXSCREEN));
-	point.y = MOUSE_COORD_TO_ABS(point.y, GetSystemMetrics(SM_CYSCREEN));
-	INPUT mouseInput;
-	mouseInput.type = INPUT_MOUSE;
-	mouseInput.mi.dx = point.x;
-	mouseInput.mi.dy = point.y;
-	mouseInput.mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE;
-	mouseInput.mi.time = 0; //System will provide the timestamp
-	mouseInput.mi.dwExtraInfo = 0;
-	mouseInput.mi.mouseData = 0;
-	SendInput(1, &mouseInput, sizeof(mouseInput));
 
+	if(vscreenWidth<0 || vscreenHeight<0)
+		updateScreenMetrics();
+
+	//Mouse motion is now done using SendInput with MOUSEINPUT. We use Absolute mouse positioning
+	#define MOUSE_COORD_TO_ABS(coord, width_or_height) ((65536 * (coord) / width_or_height) + ((coord) < 0 ? -1 : 1))
+
+	size_t x = MOUSE_COORD_TO_ABS(point.x-vscreenMinX, vscreenWidth);
+	size_t y = MOUSE_COORD_TO_ABS(point.y-vscreenMinY, vscreenHeight);
+
+	INPUT mouseInput = {0};
+	mouseInput.type = INPUT_MOUSE;
+	mouseInput.mi.dx = x;
+	mouseInput.mi.dy = y;
+	mouseInput.mi.dwFlags = MOUSEEVENTF_ABSOLUTE | MOUSEEVENTF_MOVE | MOUSEEVENTF_VIRTUALDESK;
+	mouseInput.mi.time = 0; //System will provide the timestamp
+
+	SendInput(1, &mouseInput, sizeof(mouseInput));
 #endif
 }
 

--- a/src/mouse.h
+++ b/src/mouse.h
@@ -57,6 +57,12 @@ enum __MMMouseWheelDirection
 };
 typedef int MMMouseWheelDirection;
 
+/* Updates information about current virtual screen size and coordinates
+ * in Windows
+ * It is up to the caller to ensure that this called before mouse moving
+*/
+void updateScreenMetrics();
+
 /* Immediately moves the mouse to the given point on-screen.
  * It is up to the caller to ensure that this point is within the
  * screen boundaries. */

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -88,6 +88,13 @@ NAN_METHOD(dragMouse)
 	info.GetReturnValue().Set(Nan::New(1));
 }
 
+NAN_METHOD(updateScreenMetrics)
+{
+	updateScreenMetrics();
+
+	info.GetReturnValue().Set(Nan::New(1));
+}
+
 NAN_METHOD(moveMouse)
 {
 	if (info.Length() != 2)
@@ -816,6 +823,9 @@ NAN_MODULE_INIT(InitAll)
 {
 	Nan::Set(target, Nan::New("dragMouse").ToLocalChecked(),
 		Nan::GetFunction(Nan::New<FunctionTemplate>(dragMouse)).ToLocalChecked());
+
+	Nan::Set(target, Nan::New("updateScreenMetrics").ToLocalChecked(),
+		Nan::GetFunction(Nan::New<FunctionTemplate>(updateScreenMetrics)).ToLocalChecked());
 
 	Nan::Set(target, Nan::New("moveMouse").ToLocalChecked(),
 		Nan::GetFunction(Nan::New<FunctionTemplate>(moveMouse)).ToLocalChecked());


### PR DESCRIPTION
RobotJS fails on Windows 10 environment with multiple displays when a primary display is not located on top left corner of entire virtual screen or displays have different resolutions and dpi scale factors.
It fixes #400