### PR TITLE
Reduce compilation warnings

### DIFF
--- a/src/keypress.c
+++ b/src/keypress.c
@@ -206,14 +206,14 @@ void toggleUnicodeKey(unsigned long ch, const bool down)
 
 	if (ch > 0xFFFF) {
 		// encode to utf-16 if necessary
-		unsigned short surrogates[] = {
+		UniChar surrogates[2] = {
 			0xD800 + ((ch - 0x10000) >> 10),
 			0xDC00 + (ch & 0x3FF)
 		};
 
-		CGEventKeyboardSetUnicodeString(keyEvent, 2, &surrogates);
+		CGEventKeyboardSetUnicodeString(keyEvent, 2, (UniChar*) &surrogates);
 	} else {
-		CGEventKeyboardSetUnicodeString(keyEvent, 1, &ch);
+		CGEventKeyboardSetUnicodeString(keyEvent, 1, (UniChar*) &ch);
 	}
 
 	CGEventPost(kCGSessionEventTap, keyEvent);


### PR DESCRIPTION
It appears that a cast can reduce some of the compile warnings.

See also:

* https://github.com/octalmage/robotjs/issues/183
* https://github.com/octalmage/robotjs/issues/413

The compile warnings were:

```
../src/keypress.c:214:48: warning: incompatible pointer types passing 'unsigned short (*)[2]' to parameter of type
      'const UniChar * _Nullable' (aka 'const unsigned short *') [-Wincompatible-pointer-types]
                CGEventKeyboardSetUnicodeString(keyEvent, 2, &surrogates);
                                                             ^~~~~~~~~~~
/System/Library/Frameworks/CoreGraphics.framework/Headers/CGEvent.h:206:59: note: passing argument to parameter 'unicodeString' here
    UniCharCount stringLength, const UniChar * __nullable unicodeString)
                                                          ^
../src/keypress.c:216:48: warning: incompatible pointer types passing 'unsigned long *' to parameter of type
      'const UniChar * _Nullable' (aka 'const unsigned short *') [-Wincompatible-pointer-types]
                CGEventKeyboardSetUnicodeString(keyEvent, 1, &ch);
                                                             ^~~
/System/Library/Frameworks/CoreGraphics.framework/Headers/CGEvent.h:206:59: note: passing argument to parameter 'unicodeString' here
    UniCharCount stringLength, const UniChar * __nullable unicodeString)
```