### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ npm install -g node-gyp
 Then build:
 
 ```
+cd ./node_modules/robotjs
 node-gyp rebuild
 ```
 


### PR DESCRIPTION
Readme has incorrect/incomplete build instructions.  Users must change directories into the robotjs module dir for `node-gyp rebuild` to work