### PR TITLE
Add markdown supported checkboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ See the [node-gyp readme](https://github.com/nodejs/node-gyp#installation) for m
 
 ## Plans
 
-* √ Control the mouse by changing the mouse position, left/right clicking, and dragging.
-* √ Control the keyboard by pressing keys, holding keys down, and typing words.
-* √ Read pixel color from the screen and capture the screen.
-* Find an image on screen, read pixels from an image.
-* Possibly include window management?
+- [x] Control the mouse by changing the mouse position, left/right clicking, and dragging.
+- [x] Control the keyboard by pressing keys, holding keys down, and typing words.
+- [x] Read pixel color from the screen and capture the screen.
+- [ ] Find an image on screen, read pixels from an image.
+- [ ] Possibly include window management?
 
 ## Progress
 


### PR DESCRIPTION
Hey, I replaced the check marks on the README with actual checkboxes, supported by markdown.
It looks like this now:
![image](https://user-images.githubusercontent.com/31022056/50227913-26fc4700-03a7-11e9-97e9-a5f2139ef829.png)
