### PR TITLE
Faster typing in Windows

### DIFF
--- a/src/keypress.c
+++ b/src/keypress.c
@@ -16,7 +16,7 @@
 /* Convenience wrappers around ugly APIs. */
 #if defined(IS_WINDOWS)
 	#define WIN32_KEY_EVENT_WAIT(key, flags) \
-		(win32KeyEvent(key, flags), Sleep(DEADBEEF_RANDRANGE(63, 125)))
+		win32KeyEvent(key, flags)
 #elif defined(USE_X11)
 	#define X_KEY_EVENT(display, key, is_press) \
 		(XTestFakeKeyEvent(display, \


### PR DESCRIPTION
Currently it takes about 200ms per key press, with this PR about 15ms
Fixes https://github.com/octalmage/robotjs/issues/530
Fixes https://github.com/octalmage/robotjs/issues/547