### PR TITLE
Harden screen test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "index.d.ts",
   "scripts": {
     "test": "run-script-os",
-    "test:darwin:linux": "jasmine 'test/**/*.js'",
+    "test:darwin:linux": "jasmine test/**/*.js",
     "test-keyboard": "node test/keyboard.js",
     "test:win32": "jasmine test/**/*.js",
     "install": "prebuild-install || node-gyp rebuild",

--- a/test/integration/screen.js
+++ b/test/integration/screen.js
@@ -17,9 +17,18 @@ describe('Integration/Screen', () => {
 		target = null;
 	});
 
-	it('reads a pixel color', () => {
-		var color_1 = elements.color_1;
-		const color = robot.getPixelColor(color_1.x, color_1.y);
-		expect(color).toEqual('c0ff33');
+	it('reads a pixel color', (done) => {
+		const maxDelay = 1000
+		jasmine.DEFAULT_TIMEOUT_INTERVAL = maxDelay + 1000
+		const expected = 'c0ff33'
+		const color_1 = elements.color_1;
+		const sleepTime = robot.getPixelColor(color_1.x, color_1.y) === expected ? 0
+			: maxDelay
+
+		setTimeout(() => {
+			const color = robot.getPixelColor(color_1.x, color_1.y);
+			expect(color).toEqual(expected);
+			done()
+		}, sleepTime)
 	});
 });


### PR DESCRIPTION
The screen test randomly fails if your window manager takes a little bit longer than normal. Which is particularly the case in large screens such as 4k+ monitors or slow GPUs.

I added an optional 1 second delay if the first attempt fails. In Mocha it runs in parallel, so using interval might slow down other tests without any real benefit... hence why I'm using timeout. Speaking of Mocha, it supports retries and is generally better supported than Jasmine... we should switch. The syntax is very similar.