### PR TITLE
src/keycode: fix buffer overflow

### DIFF
--- a/src/keycode.c
+++ b/src/keycode.c
@@ -68,7 +68,7 @@ MMKeyCode keyCodeForChar(const char c)
 	/* OS X does not appear to have a built-in function for this, so instead we
 	 * have to write our own. */
 	static CFMutableDictionaryRef charToCodeDict = NULL;
-	CGKeyCode code;
+	size_t code;
 	UniChar character = c;
 	CFStringRef charStr = NULL;
 


### PR DESCRIPTION
At
https://github.com/octalmage/robotjs/blob/b26c7ee0e3dd05420370350e540c48ae9d38f06c/src/keycode.c#L98,
`sizeof(void*)` bytes (probably 8) are written to a memory
segment of 2 bytes (a 16-bit CGKeycode variable), resulting in all
kinds of weird behaviour, like unrelated variables getting NULLed.

Making `code` a a type that can hold `sizeof(void*)` bytes fixes this.

Closes #570