### PR TITLE
Added note about missing maintainers to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<h1 align="center">ATTENTION: THIS PROJECT IS CURRENTLY UNMAINTAINED!</h1>
+
 <p align="center"><img src="https://cldup.com/1ATDf2JMtv.png"></p>
 
 <p align="center"><a href="https://travis-ci.org/octalmage/robotjs"><img src="https://api.travis-ci.org/octalmage/robotjs.svg?branch=master"></a> <a href="https://ci.appveyor.com/project/octalmage/robotjs"><img src="https://ci.appveyor.com/api/projects/status/qh2eqb37j7ap6x36?svg=true"></a> <a href="https://www.npmjs.com/package/robotjs"><img src="https://img.shields.io/npm/v/robotjs.svg"></a> <a href="https://gitter.im/octalmage/robotjs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img src="https://img.shields.io/badge/gitter-join%20chat-blue.svg"></a> <a href="http://waffle.io/octalmage/robotjs"><img src="https://img.shields.io/waffle/label/octalmage/robotjs/ready.svg?maxAge=3600"></a></p>


### PR DESCRIPTION
I added a note about missing maintainers for various reasons:

- No commits / merges for over half a year
- No proper release (0.6.0 only supports macOS and is therefore broken
- No recent releases since end of 2019
- No support for recent node versions
- Lots of unresolved issues