### PR TITLE
Making robotjs context-aware

### DIFF
--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -931,4 +931,10 @@ NAN_MODULE_INIT(InitAll)
 		Nan::GetFunction(Nan::New<FunctionTemplate>(setXDisplayName)).ToLocalChecked());
 }
 
+#if NODE_MAJOR_VERSION >= 10
+NODE_MODULE_INIT() {
+    InitAll(exports);
+}
+#else
 NODE_MODULE(robotjs, InitAll)
+#endif

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -933,7 +933,7 @@ NAN_MODULE_INIT(InitAll)
 
 #if NODE_MAJOR_VERSION >= 10
 NODE_MODULE_INIT() {
-    InitAll(exports);
+	InitAll(exports);
 }
 #else
 NODE_MODULE(robotjs, InitAll)


### PR DESCRIPTION
## Issue
This is an attempt to fix #580 and make robotjs context-aware and usable in the latest versions of [Electron](https://github.com/electron/electron):

```
[1] (node:82611) Electron: Loading non-context-aware native module in renderer: '[...]/electron-app/node_modules/robotjs/build/Release/robotjs.node'. This is deprecated, see https://github.com/electron/electron/issues/18397.
```

Reproduceble just by requiring `robotjs` anywhere in an Electron `>= 9.0.0` app.

## Electron and native apps

- Electron 9 switched `app.allowRendererProcessReuse` to `true` by default, making robotjs throw a deprecated error when instantiated (workaround is to put this value to `false`)
- Electron 10 will deprecate the ability to switch manually this value
- Electron 12 will remove the ability to switch manually this value

This means robotjs will simply stop working on Electron in the future. 

Source: https://github.com/electron/electron/issues/18397

## Changes

Context-awareness was added to `node` since version 10, to keep robotjs backward-compatible, I've put the new initialization in a version condition.

## Tests

I tested on an Electron `9.4.0` app: it got rid of the error and I was able to [use robotjs](https://imgur.com/l2bs7FA).

* * *
_Disclaimer: I'm not a `C` or `C++` developer at all, I would need review so I'm not introducing something unwanted. Based myself on https://nodejs.org/api/addons.html#addons_context_aware_addons._