### PR TITLE
Make robotjs context-aware for electron 14+

### DIFF
--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -931,4 +931,4 @@ NAN_MODULE_INIT(InitAll)
 		Nan::GetFunction(Nan::New<FunctionTemplate>(setXDisplayName)).ToLocalChecked());
 }
 
-NODE_MODULE(robotjs, InitAll)
+NAN_MODULE_WORKER_ENABLED(robotjs, InitAll)


### PR DESCRIPTION
Electron 14+ refuse to load robotjs on the renderer
See https://github.com/electron/electron/issues/18397 for details

Closes: #580 