### PR TITLE
Fix createStringForKey segmentation fault on Mac OS for non-Latin languages

### DIFF
--- a/src/keycode.c
+++ b/src/keycode.c
@@ -134,7 +134,7 @@ MMKeyCode keyCodeForChar(const char c)
 
 CFStringRef createStringForKey(CGKeyCode keyCode)
 {
-	TISInputSourceRef currentKeyboard = TISCopyCurrentASCIICapableKeyboardInputSource();
+	TISInputSourceRef currentKeyboard = TISCopyCurrentKeyboardLayoutInputSource();
 	CFDataRef layoutData =
 		TISGetInputSourceProperty(currentKeyboard,
 		                          kTISPropertyUnicodeKeyLayoutData);


### PR DESCRIPTION
![Screen Shot 2022-01-13 at 15 58 18](https://user-images.githubusercontent.com/48834179/149298722-87913c9f-279f-47a1-84aa-b4547cec4f55.png)

**Segmantation Fault** occurs if it is non-latin input source on MacOS.
I fixed this issue by changing from 
```
TISCopyCurrentASCIICapableKeyboardInputSource
```
to
```
TISCopyCurrentKeyboardLayoutInputSource
```

in **createStringForKey** function.
Tested with **_2-set Korean_**, **_3-set Korean_**  and **_Simple Telex_**

Refer to this link
https://jongampark.wordpress.com/tag/keyboard-input/
