### PR TITLE
fix: keyTap throws "Invalid key code" for valid keys due to dangling pointer

### DIFF
--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -511,8 +511,11 @@ Napi::Value keyTapWrapper(const Napi::CallbackInfo& info)
 	MMKeyCode key;
 	const char *k;
 
-	Napi::String kstr(env, info[0].ToString());
-	k = kstr.Utf8Value().c_str();
+	//Get arguments from JavaScript.
+	std::string kstr = info[0].As<Napi::String>();
+
+	//Convert arguments to chars.
+	k = kstr.c_str();
 
 	switch (info.Length())
 	{


### PR DESCRIPTION
Issue: https://github.com/octalmage/robotjs/issues/789

## Description

`robot.keyTap("tab")` and other valid multi-character key names throw `Error: Invalid key code specified` due to a dangling pointer bug in `keyTapWrapper`.

## Root Cause

In `src/robotjs.cc`, the `keyTapWrapper` function was doing this:

```cpp
Napi::String kstr(env, info[0].ToString());
k = kstr.Utf8Value().c_str();
```
`kstr.Utf8Value()` returns a temporary `std::string`. Taking `.c_str()` from it gives a raw pointer that becomes invalid as soon as the temporary is destroyed - at the end of that same statement. By the time `k` is passed to `CheckKeyCodes()`, it is a dangling pointer pointing to freed memory, causing the key name lookup against the `key_names` table to fail unpredictably.

This is a non-deterministic bug - it may work in some environments depending on whether the freed memory has been overwritten.

## Fix
Changed `keyTapWrapper` to store the string in a named `std::string` that lives for the full function scope, matching the pattern already used in `keyToggleWrapper`:

```cpp
std::string kstr = info[0].As<Napi::String>();
k = kstr.c_str();
```

## Files Changed
- robotjs.cc - keyTapWrapper function only

## Testing
Verified that `robot.keyTap("tab")` and other named keys (enter, backspace, escape, etc.) no longer throw Invalid key code specified after the fix.