### PR TITLE
Fix stack buffer overflow in keyCodeForChar on macOS

### DIFF
--- a/src/keycode.c
+++ b/src/keycode.c
@@ -94,9 +94,14 @@ MMKeyCode keyCodeForChar(const char c)
 	charStr = CFStringCreateWithCharacters(kCFAllocatorDefault, &character, 1);
 
 	/* Our values may be NULL (0), so we need to use this function. */
-	if (!CFDictionaryGetValueIfPresent(charToCodeDict, charStr,
-	                                   (const void **)&code)) {
-		code = UINT16_MAX; /* Error */
+	{
+		const void *charCodeValue = NULL;
+		if (!CFDictionaryGetValueIfPresent(charToCodeDict, charStr,
+		                                   &charCodeValue)) {
+			code = UINT16_MAX; /* Error */
+		} else {
+			code = (CGKeyCode)(uintptr_t)charCodeValue;
+		}
 	}
 
 	CFRelease(charStr);


### PR DESCRIPTION
Fixes #800

### Problem

`keyCodeForChar()` passes a `CGKeyCode` (`uint16_t`, 2 bytes) to `CFDictionaryGetValueIfPresent`, which writes a `const void *` (8 bytes) through the `(const void **)&code` cast — a 6-byte stack buffer overflow. The npm prebuilt tolerates it; a source build can `SIGSEGV` in `CheckKeyCodes` on any single-character key.

### Change

Read the value into a `const void *` and narrow it afterwards. No behavioural change for valid lookups; the not-found path still yields `UINT16_MAX`.

```c
const void *charCodeValue = NULL;
if (!CFDictionaryGetValueIfPresent(charToCodeDict, charStr, &charCodeValue)) {
    code = UINT16_MAX;
} else {
    code = (CGKeyCode)(uintptr_t)charCodeValue;
}
```

Single file, macOS-only path.
