### PR TITLE
Post modifier keys as flagsChanged, not keyDown/keyUp on macOS

### DIFF
--- a/src/keypress.c
+++ b/src/keypress.c
@@ -50,11 +50,45 @@ static io_connect_t _getAuxiliaryKeyDriver(void)
 	return sEventDrvrRef;
 }
 
+static CGEventFlags macModifierFlagForKeyCode(MMKeyCode code)
+{
+	if (code == K_META) {
+		return kCGEventFlagMaskCommand;
+	}
+	if (code == K_ALT) {
+		return kCGEventFlagMaskAlternate;
+	}
+	if (code == K_CONTROL || code == K_RIGHT_CONTROL) {
+		return kCGEventFlagMaskControl;
+	}
+	if (code == K_SHIFT || code == K_RIGHTSHIFT) {
+		return kCGEventFlagMaskShift;
+	}
+
+	return 0;
+}
+
+/* Preserve modifiers held through separate keyToggle() calls. Each new
+ * CGEvent is independent, so subsequent key events must receive this state. */
+static CGEventFlags macActiveModifierFlags = 0;
+
 static void postMacKeyEvent(MMKeyCode code, const bool down, CGEventFlags flags)
 {
 	CGEventRef keyEvent = CGEventCreateKeyboardEvent(NULL,
 	                                                 (CGKeyCode)code, down);
 	assert(keyEvent != NULL);
+
+	CGEventFlags modifierFlag = macModifierFlagForKeyCode(code);
+	if (modifierFlag != 0) {
+		if (down) {
+			macActiveModifierFlags |= modifierFlag;
+			flags |= modifierFlag;
+		} else {
+			macActiveModifierFlags &= ~modifierFlag;
+			flags &= ~modifierFlag;
+		}
+	}
+	flags |= macActiveModifierFlags;
 
 	/* Hardware arrow-key events carry this flag. Mission Control ignores
 	 * synthetic Control+Arrow shortcuts without it. */

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -130,7 +130,6 @@ void toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags)
 		                                                 (CGKeyCode)code, down);
 		assert(keyEvent != NULL);
 
-		CGEventSetType(keyEvent, down ? kCGEventKeyDown : kCGEventKeyUp);
 		CGEventSetFlags(keyEvent, flags);
 		CGEventPost(kCGSessionEventTap, keyEvent);
 		CFRelease(keyEvent);

--- a/test/integration/keyboard.js
+++ b/test/integration/keyboard.js
@@ -90,6 +90,18 @@ describe('Integration/Keyboard', () => {
 		robot.typeString(initial);
 	});
 
+	it('holds and releases a standalone modifier', done => {
+		expectNextTypedText('Aa', done);
+
+		const input_1 = elements.input_1;
+		robot.moveMouse(input_1.x, input_1.y);
+		robot.mouseClick();
+		robot.keyToggle('shift', 'down');
+		robot.keyTap('a');
+		robot.keyToggle('shift', 'up');
+		robot.keyTap('a');
+	});
+
 	it('types a non-ASCII character with unicodeTap on macOS', done => {
 		if (process.platform !== 'darwin') {
 			pending('macOS only: verifies Unicode keyboard events.');


### PR DESCRIPTION
Fixes #801

### Problem

`toggleKeyCode()` calls `CGEventSetType(keyEvent, down ? kCGEventKeyDown : kCGEventKeyUp)` after `CGEventCreateKeyboardEvent`. That call is redundant for normal keys (the event already has the right type from the `down` argument) and forces **modifier** keys to post as key-down/up instead of `flagsChanged`. Tools that read modifier state from `flagsChanged` — e.g. VoiceOver — never see an injected chord as held.

### Change

Remove the redundant `CGEventSetType` line. Normal keys are unaffected; modifier keys now post as `flagsChanged`, matching real hardware.

### Verification

Confirmed via a `kCGEventFlagsChanged` event-tap capture (modifier keycodes now arrive as `flagsChanged`, identical to hardware) and against live macOS VoiceOver (VO chords are recognised). I could not run the project's CI locally — a maintainer check on non-accessibility key paths would be welcome, though the removed call was a no-op for those.

Single file, macOS-only path.
