### PR TITLE
fix(macOS): support Control+Arrow Space shortcuts

### DIFF
--- a/src/keypress.c
+++ b/src/keypress.c
@@ -49,6 +49,29 @@ static io_connect_t _getAuxiliaryKeyDriver(void)
 	}
 	return sEventDrvrRef;
 }
+
+static IOOptionBits nxEventFlagsForMMKeyFlags(MMKeyFlags flags)
+{
+	IOOptionBits nxFlags = 0;
+
+	if (flags & MOD_META) nxFlags |= NX_COMMANDMASK;
+	if (flags & MOD_ALT) nxFlags |= NX_ALTERNATEMASK;
+	if (flags & MOD_CONTROL) nxFlags |= NX_CONTROLMASK;
+	if (flags & MOD_SHIFT) nxFlags |= NX_SHIFTMASK;
+
+	return nxFlags;
+}
+
+static IOOptionBits nxEventFlagsForModifierKeyCode(MMKeyCode code)
+{
+	if (code == K_META) return NX_COMMANDMASK;
+	if (code == K_ALT || code == K_RIGHT_ALT) return NX_ALTERNATEMASK;
+	if (code == K_CONTROL || code == K_LEFT_CONTROL || code == K_RIGHT_CONTROL) return NX_CONTROLMASK;
+	if (code == K_SHIFT || code == K_RIGHTSHIFT) return NX_SHIFTMASK;
+	if (code == K_CAPSLOCK) return NX_ALPHASHIFTMASK;
+
+	return 0;
+}
 #endif
 
 #if defined(IS_WINDOWS)
@@ -126,14 +149,33 @@ void toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags)
 		kr = IOHIDPostEvent( _getAuxiliaryKeyDriver(), NX_SYSDEFINED, loc, &event, kNXEventDataVersion, 0, FALSE );
 		assert( KERN_SUCCESS == kr );
 	} else {
-		CGEventRef keyEvent = CGEventCreateKeyboardEvent(NULL,
-		                                                 (CGKeyCode)code, down);
-		assert(keyEvent != NULL);
+		kern_return_t kr;
+		IOGPoint loc = { 0, 0 };
+		NXEventData event;
+		IOOptionBits eventFlags;
 
-		CGEventSetType(keyEvent, down ? kCGEventKeyDown : kCGEventKeyUp);
-		CGEventSetFlags(keyEvent, flags);
-		CGEventPost(kCGSessionEventTap, keyEvent);
-		CFRelease(keyEvent);
+		bzero(&event, sizeof(NXEventData));
+		event.key.repeat = FALSE;
+		event.key.charCode = 0;
+		event.key.charSet = 0;
+		event.key.origCharCode = 0;
+		event.key.origCharSet = 0;
+		event.key.keyboardType = 0;
+		event.key.keyCode = (UInt16)code;
+
+		eventFlags = nxEventFlagsForMMKeyFlags(flags);
+		if (down) {
+			eventFlags |= nxEventFlagsForModifierKeyCode(code);
+		}
+
+		kr = IOHIDPostEvent(_getAuxiliaryKeyDriver(),
+		                    down ? NX_KEYDOWN : NX_KEYUP,
+		                    loc,
+		                    &event,
+		                    kNXEventDataVersion,
+		                    eventFlags,
+		                    kIOHIDSetGlobalEventFlags);
+		assert(KERN_SUCCESS == kr);
 	}
 #elif defined(IS_WINDOWS)
 	const DWORD dwFlags = down ? 0 : KEYEVENTF_KEYUP;
@@ -270,7 +312,7 @@ void toggleUnicode(UniChar ch, const bool down)
 		CGEventKeyboardSetUnicodeString(keyEvent, 1, (UniChar*) &ch);
 	}
 
-	CGEventPost(kCGSessionEventTap, keyEvent);
+	CGEventPost(kCGHIDEventTap, keyEvent);
 	CFRelease(keyEvent);
 }
 #elif defined(USE_X11)

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -49,29 +49,6 @@ static io_connect_t _getAuxiliaryKeyDriver(void)
 	}
 	return sEventDrvrRef;
 }
-
-static IOOptionBits nxEventFlagsForMMKeyFlags(MMKeyFlags flags)
-{
-	IOOptionBits nxFlags = 0;
-
-	if (flags & MOD_META) nxFlags |= NX_COMMANDMASK;
-	if (flags & MOD_ALT) nxFlags |= NX_ALTERNATEMASK;
-	if (flags & MOD_CONTROL) nxFlags |= NX_CONTROLMASK;
-	if (flags & MOD_SHIFT) nxFlags |= NX_SHIFTMASK;
-
-	return nxFlags;
-}
-
-static IOOptionBits nxEventFlagsForModifierKeyCode(MMKeyCode code)
-{
-	if (code == K_META) return NX_COMMANDMASK;
-	if (code == K_ALT || code == K_RIGHT_ALT) return NX_ALTERNATEMASK;
-	if (code == K_CONTROL || code == K_LEFT_CONTROL || code == K_RIGHT_CONTROL) return NX_CONTROLMASK;
-	if (code == K_SHIFT || code == K_RIGHTSHIFT) return NX_SHIFTMASK;
-	if (code == K_CAPSLOCK) return NX_ALPHASHIFTMASK;
-
-	return 0;
-}
 #endif
 
 #if defined(IS_WINDOWS)
@@ -149,33 +126,21 @@ void toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags)
 		kr = IOHIDPostEvent( _getAuxiliaryKeyDriver(), NX_SYSDEFINED, loc, &event, kNXEventDataVersion, 0, FALSE );
 		assert( KERN_SUCCESS == kr );
 	} else {
-		kern_return_t kr;
-		IOGPoint loc = { 0, 0 };
-		NXEventData event;
-		IOOptionBits eventFlags;
+		CGEventFlags eventFlags = (CGEventFlags)flags;
+		CGEventRef keyEvent = CGEventCreateKeyboardEvent(NULL,
+		                                                 (CGKeyCode)code, down);
+		assert(keyEvent != NULL);
 
-		bzero(&event, sizeof(NXEventData));
-		event.key.repeat = FALSE;
-		event.key.charCode = 0;
-		event.key.charSet = 0;
-		event.key.origCharCode = 0;
-		event.key.origCharSet = 0;
-		event.key.keyboardType = 0;
-		event.key.keyCode = (UInt16)code;
-
-		eventFlags = nxEventFlagsForMMKeyFlags(flags);
-		if (down) {
-			eventFlags |= nxEventFlagsForModifierKeyCode(code);
+		/* Hardware arrow-key events carry this flag. Mission Control ignores
+		 * synthetic Control+Arrow shortcuts without it. */
+		if (code == K_UP || code == K_DOWN || code == K_LEFT || code == K_RIGHT) {
+			eventFlags |= kCGEventFlagMaskSecondaryFn;
 		}
 
-		kr = IOHIDPostEvent(_getAuxiliaryKeyDriver(),
-		                    down ? NX_KEYDOWN : NX_KEYUP,
-		                    loc,
-		                    &event,
-		                    kNXEventDataVersion,
-		                    eventFlags,
-		                    kIOHIDSetGlobalEventFlags);
-		assert(KERN_SUCCESS == kr);
+		CGEventSetType(keyEvent, down ? kCGEventKeyDown : kCGEventKeyUp);
+		CGEventSetFlags(keyEvent, eventFlags);
+		CGEventPost(kCGSessionEventTap, keyEvent);
+		CFRelease(keyEvent);
 	}
 #elif defined(IS_WINDOWS)
 	const DWORD dwFlags = down ? 0 : KEYEVENTF_KEYUP;
@@ -312,7 +277,7 @@ void toggleUnicode(UniChar ch, const bool down)
 		CGEventKeyboardSetUnicodeString(keyEvent, 1, (UniChar*) &ch);
 	}
 
-	CGEventPost(kCGHIDEventTap, keyEvent);
+	CGEventPost(kCGSessionEventTap, keyEvent);
 	CFRelease(keyEvent);
 }
 #elif defined(USE_X11)

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -512,6 +512,13 @@ Napi::Value keyTapWrapper(const Napi::CallbackInfo& info)
 
 	MMKeyFlags flags = MOD_NONE;
 	MMKeyCode key;
+
+	if (info.Length() < 1 || info.Length() > 2)
+	{
+		Napi::Error::New(env, "Invalid number of arguments.").ThrowAsJavaScriptException();
+return env.Null();
+	}
+
 	std::string kstr = info[0].ToString().Utf8Value();
 	const char *k = kstr.c_str();
 
@@ -532,9 +539,6 @@ return env.Null();
 			break;
 		case 1:
 			break;
-		default:
-			Napi::Error::New(env, "Invalid number of arguments.").ThrowAsJavaScriptException();
-return env.Null();
 	}
 
 	switch(CheckKeyCodes(k, &key))

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -16,10 +16,6 @@
 int mouseDelay = 10;
 int keyboardDelay = 10;
 
-#if defined(IS_MACOSX)
-static const unsigned MACOS_TYPE_STRING_DEFAULT_CPM = 1000;
-#endif
-
 /*
  __  __
 |  \/  | ___  _   _ ___  ___
@@ -512,13 +508,6 @@ Napi::Value keyTapWrapper(const Napi::CallbackInfo& info)
 
 	MMKeyFlags flags = MOD_NONE;
 	MMKeyCode key;
-
-	if (info.Length() < 1 || info.Length() > 2)
-	{
-		Napi::Error::New(env, "Invalid number of arguments.").ThrowAsJavaScriptException();
-return env.Null();
-	}
-
 	std::string kstr = info[0].ToString().Utf8Value();
 	const char *k = kstr.c_str();
 
@@ -539,6 +528,9 @@ return env.Null();
 			break;
 		case 1:
 			break;
+		default:
+			Napi::Error::New(env, "Invalid number of arguments.").ThrowAsJavaScriptException();
+return env.Null();
 	}
 
 	switch(CheckKeyCodes(k, &key))
@@ -677,11 +669,7 @@ Napi::Value typeStringWrapper(const Napi::CallbackInfo& info)
 
 		s = str.c_str();
 
-		#if defined(IS_MACOSX)
-			typeStringDelayed(s, MACOS_TYPE_STRING_DEFAULT_CPM);
-		#else
-			typeStringDelayed(s, 0);
-		#endif
+		typeStringDelayed(s, 0);
 
 		return Napi::Number::New(env, 1);
 	} else {

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -16,6 +16,10 @@
 int mouseDelay = 10;
 int keyboardDelay = 10;
 
+#if defined(IS_MACOSX)
+static const unsigned MACOS_TYPE_STRING_DEFAULT_CPM = 1000;
+#endif
+
 /*
  __  __
 |  \/  | ___  _   _ ___  ___
@@ -669,7 +673,11 @@ Napi::Value typeStringWrapper(const Napi::CallbackInfo& info)
 
 		s = str.c_str();
 
-		typeStringDelayed(s, 0);
+		#if defined(IS_MACOSX)
+			typeStringDelayed(s, MACOS_TYPE_STRING_DEFAULT_CPM);
+		#else
+			typeStringDelayed(s, 0);
+		#endif
 
 		return Napi::Number::New(env, 1);
 	} else {


### PR DESCRIPTION
## Problem

`robot.keyTap('right', 'control')` did not trigger the macOS Mission Control shortcut for moving between Spaces. Synthetic arrow-key events were missing the `kCGEventFlagMaskSecondaryFn` flag carried by physical arrow-key events.

## Change

- Keep regular keyboard and Unicode delivery on the public `CGEvent` path.
- Add `kCGEventFlagMaskSecondaryFn` only to synthetic arrow-key events.
- Leave the existing IOHID path limited to media keys.

This replaces the earlier broad IOHID experiment, which used a deprecated API for every key and changed unrelated typing behavior.

## Verification

- Built the native addon on macOS arm64 / Node 25.
- `robot.keyTap('left', 'control')`: active Space changed `983 -> 1`.
- `robot.keyTap('right', 'control')`: active Space changed `1 -> 983`.
- `test/keyboard.js`: 8 specs, 0 failures.
