### PR TITLE
fix(macOS): emit explicit modifier events.

### DIFF
--- a/src/keypress.c
+++ b/src/keypress.c
@@ -49,6 +49,24 @@ static io_connect_t _getAuxiliaryKeyDriver(void)
 	}
 	return sEventDrvrRef;
 }
+
+static void postMacKeyEvent(MMKeyCode code, const bool down, CGEventFlags flags)
+{
+	CGEventRef keyEvent = CGEventCreateKeyboardEvent(NULL,
+	                                                 (CGKeyCode)code, down);
+	assert(keyEvent != NULL);
+
+	/* Hardware arrow-key events carry this flag. Mission Control ignores
+	 * synthetic Control+Arrow shortcuts without it. */
+	if (code == K_UP || code == K_DOWN || code == K_LEFT || code == K_RIGHT) {
+		flags |= kCGEventFlagMaskSecondaryFn;
+	}
+
+	CGEventSetType(keyEvent, down ? kCGEventKeyDown : kCGEventKeyUp);
+	CGEventSetFlags(keyEvent, flags);
+	CGEventPost(kCGSessionEventTap, keyEvent);
+	CFRelease(keyEvent);
+}
 #endif
 
 #if defined(IS_WINDOWS)
@@ -125,22 +143,51 @@ void toggleKeyCode(MMKeyCode code, const bool down, MMKeyFlags flags)
 		event.compound.misc.L[0] = evtInfo;
 		kr = IOHIDPostEvent( _getAuxiliaryKeyDriver(), NX_SYSDEFINED, loc, &event, kNXEventDataVersion, 0, FALSE );
 		assert( KERN_SUCCESS == kr );
-	} else {
-		CGEventFlags eventFlags = (CGEventFlags)flags;
-		CGEventRef keyEvent = CGEventCreateKeyboardEvent(NULL,
-		                                                 (CGKeyCode)code, down);
-		assert(keyEvent != NULL);
+	} else if (down) {
+		CGEventFlags activeFlags = 0;
 
-		/* Hardware arrow-key events carry this flag. Mission Control ignores
-		 * synthetic Control+Arrow shortcuts without it. */
-		if (code == K_UP || code == K_DOWN || code == K_LEFT || code == K_RIGHT) {
-			eventFlags |= kCGEventFlagMaskSecondaryFn;
+		/* Post real modifier events around the key. Chromium and other apps
+		 * ignore bare flag bits for some shortcuts, and explicit key-up events
+		 * prevent the modifier from remaining active after the key tap. */
+		if (flags & MOD_META) {
+			activeFlags |= kCGEventFlagMaskCommand;
+			postMacKeyEvent(K_META, true, activeFlags);
+		}
+		if (flags & MOD_ALT) {
+			activeFlags |= kCGEventFlagMaskAlternate;
+			postMacKeyEvent(K_ALT, true, activeFlags);
+		}
+		if (flags & MOD_CONTROL) {
+			activeFlags |= kCGEventFlagMaskControl;
+			postMacKeyEvent(K_CONTROL, true, activeFlags);
+		}
+		if (flags & MOD_SHIFT) {
+			activeFlags |= kCGEventFlagMaskShift;
+			postMacKeyEvent(K_SHIFT, true, activeFlags);
 		}
 
-		CGEventSetType(keyEvent, down ? kCGEventKeyDown : kCGEventKeyUp);
-		CGEventSetFlags(keyEvent, eventFlags);
-		CGEventPost(kCGSessionEventTap, keyEvent);
-		CFRelease(keyEvent);
+		postMacKeyEvent(code, true, (CGEventFlags)flags);
+	} else {
+		CGEventFlags activeFlags = (CGEventFlags)flags;
+
+		postMacKeyEvent(code, false, activeFlags);
+
+		if (flags & MOD_SHIFT) {
+			activeFlags &= ~kCGEventFlagMaskShift;
+			postMacKeyEvent(K_SHIFT, false, activeFlags);
+		}
+		if (flags & MOD_CONTROL) {
+			activeFlags &= ~kCGEventFlagMaskControl;
+			postMacKeyEvent(K_CONTROL, false, activeFlags);
+		}
+		if (flags & MOD_ALT) {
+			activeFlags &= ~kCGEventFlagMaskAlternate;
+			postMacKeyEvent(K_ALT, false, activeFlags);
+		}
+		if (flags & MOD_META) {
+			activeFlags &= ~kCGEventFlagMaskCommand;
+			postMacKeyEvent(K_META, false, activeFlags);
+		}
 	}
 #elif defined(IS_WINDOWS)
 	const DWORD dwFlags = down ? 0 : KEYEVENTF_KEYUP;

--- a/test/integration/keyboard.js
+++ b/test/integration/keyboard.js
@@ -7,6 +7,24 @@ robot.setMouseDelay(100);
 var target, elements;
 var originalTimeout;
 
+function expectNextTypedText(expected, done, next) {
+	const handleType = element => {
+		if (element.id !== 'input_1') {
+			return;
+		}
+
+		target.removeListener('type', handleType);
+		expect(element.text).toEqual(expected);
+		if (next) {
+			next();
+		} else {
+			done();
+		}
+	};
+
+	target.on('type', handleType);
+}
+
 describe('Integration/Keyboard', () => {
 	beforeAll(() => {
 		originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
@@ -32,15 +50,8 @@ describe('Integration/Keyboard', () => {
 
 	it('types', done => {
 		const stringToType = 'hello world';
-		// Currently Target Practice waits for the "user" to finish typing before sending the event.
-		const handleType = element => {
-			expect(element.id).toEqual('input_1');
-			if (element.text === stringToType) {
-				target.removeListener('type', handleType);
-				done();
-			}
-		};
-		target.on('type', handleType);
+		// Target Practice emits after the user has stopped typing.
+		expectNextTypedText(stringToType, done);
 
 		const input_1 = elements.input_1;
 		robot.moveMouse(input_1.x, input_1.y);
@@ -51,19 +62,52 @@ describe('Integration/Keyboard', () => {
 	// Regression for https://github.com/octalmage/robotjs/pull/797
 	it('types shifted symbols', done => {
 		const stringToType = '!@#$%^&*()_+{}|:"<>?';
-		const handleType = element => {
-			expect(element.id).toEqual('input_1');
-			if (element.text === stringToType) {
-				target.removeListener('type', handleType);
-				done();
-			}
-		};
-		target.on('type', handleType);
+		expectNextTypedText(stringToType, done);
 
 		const input_1 = elements.input_1;
 		robot.moveMouse(input_1.x, input_1.y);
 		robot.mouseClick();
 		robot.typeString(stringToType);
+	});
+
+	it('replaces selected input with a command-modified key tap on macOS', done => {
+		if (process.platform !== 'darwin') {
+			pending('macOS only: verifies command-modified keyboard events.');
+			return;
+		}
+
+		const initial = 'initial content';
+		const replacement = 'replacement content';
+		expectNextTypedText(initial, done, () => {
+			expectNextTypedText(replacement, done);
+			robot.keyTap('a', 'command');
+			robot.typeString(replacement);
+		});
+
+		const input_1 = elements.input_1;
+		robot.moveMouse(input_1.x, input_1.y);
+		robot.mouseClick();
+		robot.typeString(initial);
+	});
+
+	it('types a non-ASCII character with unicodeTap on macOS', done => {
+		if (process.platform !== 'darwin') {
+			pending('macOS only: verifies Unicode keyboard events.');
+			return;
+		}
+
+		const marker = 'x';
+		const character = '嗨';
+		expectNextTypedText(marker, done, () => {
+			expectNextTypedText(character, done);
+			robot.keyTap('backspace');
+			robot.unicodeTap(character.charCodeAt(0));
+		});
+
+		const input_1 = elements.input_1;
+		robot.moveMouse(input_1.x, input_1.y);
+		robot.mouseClick();
+		robot.typeString(marker);
 	});
 
 	// Regression for https://github.com/octalmage/robotjs/issues/789


### PR DESCRIPTION
## Problem

macOS shortcuts only attached modifier flag bits to the primary key event. Chromium recognized `Command+A`, but Command never received a matching key-up event and remained logically active. Subsequent text was interpreted as shortcuts instead of input.

## Change

- Emit modifier key-down events before the primary key.
- Release modifiers in reverse order after the primary key-up event.
- Preserve the `SecondaryFn` arrow flag required by Mission Control.
- Synchronize integration test phases on observed text instead of racing posted events.
- Reuse the synchronized text helper in existing typing tests.

## Verification

- Keyboard integration suite repeated three times: 5 specs, 0 failures each run.
- `Command+A` replaces selected Chromium input with the expected text.
- `unicodeTap` produces `嗨` after focus is confirmed.
- `Control+Right`: active Space `1 -> 983`.
- `Control+Left`: active Space `983 -> 1`.
