### PR TITLE
0.8.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.8.0 (2026-07-19)
+
+* feat: Add image and color search, BMP I/O, optional PNG I/O, and display-aware screen capture. ([baf5616](https://github.com/octalmage/robotjs/commit/baf5616))
+* fix: Auto-detect Shift and AltGr modifiers in Linux `typeString`. ([fec80e5](https://github.com/octalmage/robotjs/commit/fec80e5))
+* fix: Preserve macOS keyboard compatibility and emit complete modifier lifecycles for shortcuts. ([0efcfa2](https://github.com/octalmage/robotjs/commit/0efcfa2), [d064384](https://github.com/octalmage/robotjs/commit/d064384))
+* test: Add integration coverage for Linux modifiers, macOS shortcuts, and repeated Unicode input. ([c2b0ea4](https://github.com/octalmage/robotjs/commit/c2b0ea4), [0d83176](https://github.com/octalmage/robotjs/commit/0d83176))
+
+
 ## 0.7.1 (2026-05-08)
 
 * fix: Add MMBitmap buffer-cleanup callback used by Windows screen capture. ([92504c3](https://github.com/octalmage/robotjs/commit/92504c3))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "robotjs",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "robotjs",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,16 @@
 {
   "name": "robotjs",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Node.js Desktop Automation.",
   "main": "index.js",
   "typings": "index.d.ts",
+  "files": [
+    "binding.gyp",
+    "CHANGELOG.md",
+    "index.js",
+    "index.d.ts",
+    "src/"
+  ],
   "scripts": {
     "test": "jasmine \"test/**/*.js\"",
     "install": "prebuild-install --runtime napi || node-gyp rebuild",


### PR DESCRIPTION
## Release

- Set the package version to `0.8.0`.
- Add release notes for image search, bitmap I/O, and keyboard fixes.
- Restrict the npm package to runtime and native-build files.

## Verification

- Packed package reports `robotjs@0.8.0`.
- Installed the packed tarball from source in a clean fixture.
- Verified image self-search, BMP save/load, and pixel reads from the installed package.
- PNG correctly reports disabled in the default source build.
