### PR TITLE
fix(Windows): normalize smooth mouse timing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* fix: Normalize smooth mouse movement timing on Windows.
+
+
 ## 0.8.0 (2026-07-19)
 
 * feat: Add image and color search, BMP I/O, optional PNG I/O, and display-aware screen capture. ([baf5616](https://github.com/octalmage/robotjs/commit/baf5616))

--- a/binding.gyp
+++ b/binding.gyp
@@ -50,7 +50,12 @@
       }],
 
       ["OS=='win'", {
-        'defines': ['IS_WINDOWS']
+        'defines': ['IS_WINDOWS'],
+        'link_settings': {
+          'libraries': [
+            'winmm.lib'
+          ]
+        }
       }],
 
       ['robotjs_enable_png==1', {

--- a/src/microsleep.h
+++ b/src/microsleep.h
@@ -23,7 +23,15 @@
 H_INLINE void microsleep(double milliseconds)
 {
 #if defined(IS_WINDOWS)
-	Sleep((DWORD)milliseconds); /* (Unfortunately truncated to a 32-bit integer.) */
+	DWORD duration;
+
+	if (milliseconds <= 0.0) {
+		Sleep(0);
+		return;
+	}
+
+	duration = (DWORD)(milliseconds + 0.5);
+	Sleep(duration > 0 ? duration : 1);
 #else
 	/* Technically, nanosleep() is not an ANSI function, but it is the most
 	 * supported precise sleeping function I can find.

--- a/src/mouse.c
+++ b/src/mouse.c
@@ -12,6 +12,8 @@
 	#include <X11/extensions/XTest.h>
 	#include <stdlib.h>
 	#include "xdisplay.h"
+#elif defined(IS_WINDOWS)
+	#include <mmsystem.h>
 #endif
 
 #if !defined(M_SQRT2)
@@ -66,6 +68,27 @@ static int vscreenMinY = 0;
 	                         : ((button) == RIGHT_BUTTON ? MOUSEEVENTF_RIGHTDOWN \
 	                                                     : MOUSEEVENTF_MIDDLEDOWN))
 
+#endif
+
+#if defined(IS_WINDOWS)
+/* Windows' default timer tick makes per-pixel sleeps much slower than on
+ * other platforms, so request finer resolution for the whole movement. */
+static UINT beginMouseTimerResolution(void)
+{
+	TIMECAPS capabilities;
+	UINT period = 1;
+
+	if (timeGetDevCaps(&capabilities, (UINT)sizeof(capabilities)) == TIMERR_NOERROR) {
+		if (period < capabilities.wPeriodMin) {
+			period = capabilities.wPeriodMin;
+		}
+		if (period > capabilities.wPeriodMax) {
+			period = capabilities.wPeriodMax;
+		}
+	}
+
+	return timeBeginPeriod(period) == TIMERR_NOERROR ? period : 0;
+}
 #endif
 
 #if defined(IS_MACOSX)
@@ -376,6 +399,13 @@ bool smoothlyMoveMouse(MMSignedPoint endPoint,double speed)
 	MMSignedPoint pos = getMousePos();
 	double velo_x = 0.0, velo_y = 0.0;
 	double distance;
+#if defined(IS_WINDOWS)
+	UINT timerPeriod;
+#endif
+
+#if defined(IS_WINDOWS)
+	timerPeriod = beginMouseTimerResolution();
+#endif
 
 	while ((distance = crude_hypot((double)pos.x - endPoint.x,
 	                               (double)pos.y - endPoint.y)) > 1.0) {
@@ -397,6 +427,12 @@ bool smoothlyMoveMouse(MMSignedPoint endPoint,double speed)
 		/* Wait 1 - (speed) milliseconds. */
 		microsleep(DEADBEEF_UNIFORM(0.7, speed));
 	}
+
+#if defined(IS_WINDOWS)
+	if (timerPeriod != 0) {
+		timeEndPeriod(timerPeriod);
+	}
+#endif
 
 	return true;
 }

--- a/test/mouse.js
+++ b/test/mouse.js
@@ -56,6 +56,26 @@ describe('Mouse', () => {
 
   });
 
+  it('Move the mouse smoothly without timer stalls.', function()
+  {
+    var initialPos;
+    var startedAt;
+    var elapsed;
+
+    initialPos = robot.getMousePos();
+
+    try {
+      robot.moveMouse(0, 100);
+      startedAt = Date.now();
+      robot.moveMouseSmooth(300, 100, 3);
+      elapsed = Date.now() - startedAt;
+    } finally {
+      robot.moveMouse(initialPos.x, initialPos.y);
+    }
+
+    expect(elapsed).toBeLessThan(2000);
+  });
+
   it('Click the mouse.', function()
   {
     expect(robot.mouseClick()).toBeTruthy();


### PR DESCRIPTION
## Problem

`moveMouseSmooth` is much slower on Windows because of the default timer resolution.

## Change

- Use 1 ms timer resolution during smooth mouse movement.
- Round fractional sleeps instead of truncating them.
- Add a smooth movement timing test.

## Verification

- A 300 px move at speed 3 improved from 1967 ms to 409 ms on Windows.