### PR TITLE
test: stabilize Target Practice integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * fix: Normalize smooth mouse movement timing on Windows.
 * fix: Write the complete BMP file size in serialized headers.
-* test: Synchronize Target Practice window readiness, input timing, and shutdown.
+* test: Adopt Target Practice 0.0.8 lifecycle and verify fixture visibility and interactivity.
 
 
 ## 0.8.0 (2026-07-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * fix: Normalize smooth mouse movement timing on Windows.
 * fix: Write the complete BMP file size in serialized headers.
+* test: Synchronize Target Practice window readiness, input timing, and shutdown.
 
 
 ## 0.8.0 (2026-07-19)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "jasmine": "^2.99.0",
         "node-gyp": "^12.2.0",
         "prebuild": "^13",
-        "targetpractice": "github:octalmage/targetpractice#2944cdf"
+        "targetpractice": "github:octalmage/targetpractice#91436489083ec93cb1438fcc8943dd23c762850b"
       }
     },
     "node_modules/@electron/get": {
@@ -5139,7 +5139,8 @@
     },
     "node_modules/targetpractice": {
       "version": "0.0.8",
-      "resolved": "git+ssh://git@github.com/octalmage/targetpractice.git#2944cdfea5188f71a08d3bea309cfb0a606bc38e",
+      "resolved": "git+ssh://git@github.com/octalmage/targetpractice.git#91436489083ec93cb1438fcc8943dd23c762850b",
+      "integrity": "sha512-z99otGljIL8nnvnLfHX+IRn0LTmW79VRCMM/DGnsXTQENLdOJHePhVxxji6D8dlZPfTBxs66Mkr1XnaAHyIG3w==",
       "dev": true,
       "dependencies": {
         "electron": "^35.7.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "jasmine": "^2.99.0",
         "node-gyp": "^12.2.0",
         "prebuild": "^13",
-        "targetpractice": "github:octalmage/targetpractice"
+        "targetpractice": "github:octalmage/targetpractice#2944cdf"
       }
     },
     "node_modules/@electron/get": {
@@ -5138,8 +5138,8 @@
       }
     },
     "node_modules/targetpractice": {
-      "version": "0.0.7",
-      "resolved": "git+ssh://git@github.com/octalmage/targetpractice.git#84629ec8d2f1ccc9cdd48a18a262a4e2b7162315",
+      "version": "0.0.8",
+      "resolved": "git+ssh://git@github.com/octalmage/targetpractice.git#2944cdfea5188f71a08d3bea309cfb0a606bc38e",
       "dev": true,
       "dependencies": {
         "electron": "^35.7.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "jasmine": "^2.99.0",
         "node-gyp": "^12.2.0",
         "prebuild": "^13",
-        "targetpractice": "github:octalmage/targetpractice#91436489083ec93cb1438fcc8943dd23c762850b"
+        "targetpractice": "github:octalmage/targetpractice"
       }
     },
     "node_modules/@electron/get": {
@@ -5139,8 +5139,7 @@
     },
     "node_modules/targetpractice": {
       "version": "0.0.8",
-      "resolved": "git+ssh://git@github.com/octalmage/targetpractice.git#91436489083ec93cb1438fcc8943dd23c762850b",
-      "integrity": "sha512-z99otGljIL8nnvnLfHX+IRn0LTmW79VRCMM/DGnsXTQENLdOJHePhVxxji6D8dlZPfTBxs66Mkr1XnaAHyIG3w==",
+      "resolved": "git+ssh://git@github.com/octalmage/targetpractice.git#b1344fe9793402f992aa92cdfd5c777b8a4c79ea",
       "dev": true,
       "dependencies": {
         "electron": "^35.7.5"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "jasmine": "^2.99.0",
     "node-gyp": "^12.2.0",
     "prebuild": "^13",
-    "targetpractice": "github:octalmage/targetpractice#2944cdf"
+    "targetpractice": "github:octalmage/targetpractice#91436489083ec93cb1438fcc8943dd23c762850b"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "jasmine": "^2.99.0",
     "node-gyp": "^12.2.0",
     "prebuild": "^13",
-    "targetpractice": "github:octalmage/targetpractice#91436489083ec93cb1438fcc8943dd23c762850b"
+    "targetpractice": "github:octalmage/targetpractice"
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "jasmine": "^2.99.0",
     "node-gyp": "^12.2.0",
     "prebuild": "^13",
-    "targetpractice": "github:octalmage/targetpractice"
+    "targetpractice": "github:octalmage/targetpractice#2944cdf"
   }
 }

--- a/test/helpers/targetpractice.js
+++ b/test/helpers/targetpractice.js
@@ -1,5 +1,5 @@
 /* jshint esversion: 8 */
-var targetpractice = require('targetpractice/index.js');
+var targetpractice = require('targetpractice');
 
 const TARGET_COLOR = 'c0ff33';
 const TRANSITION_TIMEOUT_MS = 5000;

--- a/test/helpers/targetpractice.js
+++ b/test/helpers/targetpractice.js
@@ -1,0 +1,198 @@
+/* jshint esversion: 6 */
+var targetpractice = require('targetpractice/index.js');
+
+const TARGET_COLOR = 'c0ff33';
+const TRANSITION_TIMEOUT_MS = 5000;
+const POLL_INTERVAL_MS = 25;
+const INTERACTION_POLL_INTERVAL_MS = 100;
+
+var activeSession = null;
+
+function waitForMarker(robot, point, visible) {
+	const deadline = Date.now() + TRANSITION_TIMEOUT_MS;
+	const transition = visible ? 'appear' : 'disappear';
+	let lastColor;
+
+	return new Promise((resolve, reject) => {
+		function poll() {
+			try {
+				lastColor = robot.getPixelColor(point.x, point.y);
+			} catch (error) {
+				reject(new Error(
+					'Could not sample the Target Practice marker at (' + point.x + ', ' + point.y +
+					'): ' + error.message
+				));
+				return;
+			}
+
+			if ((lastColor === TARGET_COLOR) === visible) {
+				resolve();
+				return;
+			}
+
+			if (Date.now() >= deadline) {
+				reject(new Error(
+					'Timed out after ' + TRANSITION_TIMEOUT_MS +
+					'ms waiting for the Target Practice marker at (' + point.x + ', ' + point.y +
+					') to ' + transition + '; last color was ' + lastColor + '.'
+				));
+				return;
+			}
+
+			setTimeout(poll, POLL_INTERVAL_MS);
+		}
+
+		poll();
+	});
+}
+
+function waitForInteraction(robot, target, point) {
+	const deadline = Date.now() + TRANSITION_TIMEOUT_MS;
+
+	return new Promise((resolve, reject) => {
+		let retryTimer;
+
+		function cleanup() {
+			clearTimeout(retryTimer);
+			target.removeListener('click', handleClick);
+		}
+
+		function handleClick(event) {
+			if (event.id !== 'button_1') {
+				return;
+			}
+
+			cleanup();
+			resolve();
+		}
+
+		function attempt() {
+			if (Date.now() >= deadline) {
+				cleanup();
+				reject(new Error(
+					'Timed out after ' + TRANSITION_TIMEOUT_MS +
+					'ms waiting for Target Practice to accept mouse input.'
+				));
+				return;
+			}
+
+			try {
+				robot.moveMouse(point.x, point.y);
+				robot.mouseClick();
+			} catch (error) {
+				cleanup();
+				reject(error);
+				return;
+			}
+
+			retryTimer = setTimeout(attempt, INTERACTION_POLL_INTERVAL_MS);
+		}
+
+		target.on('click', handleClick);
+		attempt();
+	});
+}
+
+function start(robot, options) {
+	options = options || {};
+	if (activeSession !== null) {
+		return Promise.reject(new Error('Target Practice is already running.'));
+	}
+
+	let target;
+	try {
+		target = targetpractice.start();
+	} catch (error) {
+		return Promise.reject(error);
+	}
+
+	const session = {
+		elements: null,
+		target: target
+	};
+	activeSession = session;
+
+	return new Promise((resolve, reject) => {
+		const elementsTimer = setTimeout(() => {
+			cleanup();
+			reject(new Error(
+				'Timed out after ' + TRANSITION_TIMEOUT_MS +
+				'ms waiting for Target Practice to report its elements.'
+			));
+		}, TRANSITION_TIMEOUT_MS);
+
+		function cleanup() {
+			clearTimeout(elementsTimer);
+			target.removeListener('elements', handleElements);
+			target.removeListener('error', handleError);
+		}
+
+		function handleError(error) {
+			cleanup();
+			reject(error);
+		}
+
+		function handleElements(elements) {
+			clearTimeout(elementsTimer);
+			target.removeListener('elements', handleElements);
+			session.elements = elements;
+
+			if (!elements.color_1) {
+				cleanup();
+				reject(new Error('Target Practice did not report its color marker.'));
+				return;
+			}
+			if (options.interactive && !elements.button_1) {
+				cleanup();
+				reject(new Error('Target Practice did not report its interaction probe.'));
+				return;
+			}
+
+			let ready = waitForMarker(robot, elements.color_1, true);
+			if (options.interactive) {
+				ready = ready.then(() => waitForInteraction(robot, target, elements.button_1));
+			}
+
+			ready.then(() => {
+				cleanup();
+				resolve(session);
+			}, error => {
+				cleanup();
+				reject(error);
+			});
+		}
+
+		target.once('elements', handleElements);
+		target.once('error', handleError);
+	});
+}
+
+function stop(robot) {
+	if (activeSession === null) {
+		return Promise.resolve();
+	}
+
+	const session = activeSession;
+	const marker = session.elements && session.elements.color_1;
+
+	try {
+		targetpractice.stop();
+	} catch (error) {
+		activeSession = null;
+		return Promise.reject(error);
+	}
+
+	const closed = marker ? waitForMarker(robot, marker, false) : Promise.resolve();
+	return closed.then(() => {
+		activeSession = null;
+	}, error => {
+		activeSession = null;
+		throw error;
+	});
+}
+
+module.exports = {
+	TARGET_COLOR: TARGET_COLOR,
+	start: start,
+	stop: stop
+};

--- a/test/helpers/targetpractice.js
+++ b/test/helpers/targetpractice.js
@@ -1,4 +1,4 @@
-/* jshint esversion: 6 */
+/* jshint esversion: 8 */
 var targetpractice = require('targetpractice/index.js');
 
 const TARGET_COLOR = 'c0ff33';
@@ -6,11 +6,8 @@ const TRANSITION_TIMEOUT_MS = 5000;
 const POLL_INTERVAL_MS = 25;
 const INTERACTION_POLL_INTERVAL_MS = 100;
 
-var activeSession = null;
-
-function waitForMarker(robot, point, visible) {
+function waitForMarker(robot, point) {
 	const deadline = Date.now() + TRANSITION_TIMEOUT_MS;
-	const transition = visible ? 'appear' : 'disappear';
 	let lastColor;
 
 	return new Promise((resolve, reject) => {
@@ -25,7 +22,7 @@ function waitForMarker(robot, point, visible) {
 				return;
 			}
 
-			if ((lastColor === TARGET_COLOR) === visible) {
+			if (lastColor === TARGET_COLOR) {
 				resolve();
 				return;
 			}
@@ -34,7 +31,7 @@ function waitForMarker(robot, point, visible) {
 				reject(new Error(
 					'Timed out after ' + TRANSITION_TIMEOUT_MS +
 					'ms waiting for the Target Practice marker at (' + point.x + ', ' + point.y +
-					') to ' + transition + '; last color was ' + lastColor + '.'
+					') to appear; last color was ' + lastColor + '.'
 				));
 				return;
 			}
@@ -93,106 +90,40 @@ function waitForInteraction(robot, target, point) {
 	});
 }
 
-function start(robot, options) {
+async function start(robot, options) {
 	options = options || {};
-	if (activeSession !== null) {
-		return Promise.reject(new Error('Target Practice is already running.'));
-	}
 
 	let target;
 	try {
-		target = targetpractice.start();
+		target = await targetpractice.start();
+		const elements = target.elements;
+
+		if (!elements.color_1) {
+			throw new Error('Target Practice did not report its color marker.');
+		}
+		if (options.interactive && !elements.button_1) {
+			throw new Error('Target Practice did not report its interaction probe.');
+		}
+
+		await waitForMarker(robot, elements.color_1);
+		if (options.interactive) {
+			await waitForInteraction(robot, target, elements.button_1);
+		}
+
+		return target;
 	} catch (error) {
-		return Promise.reject(error);
-	}
-
-	const session = {
-		elements: null,
-		target: target
-	};
-	activeSession = session;
-
-	return new Promise((resolve, reject) => {
-		const elementsTimer = setTimeout(() => {
-			cleanup();
-			reject(new Error(
-				'Timed out after ' + TRANSITION_TIMEOUT_MS +
-				'ms waiting for Target Practice to report its elements.'
-			));
-		}, TRANSITION_TIMEOUT_MS);
-
-		function cleanup() {
-			clearTimeout(elementsTimer);
-			target.removeListener('elements', handleElements);
-			target.removeListener('error', handleError);
-		}
-
-		function handleError(error) {
-			cleanup();
-			reject(error);
-		}
-
-		function handleElements(elements) {
-			clearTimeout(elementsTimer);
-			target.removeListener('elements', handleElements);
-			session.elements = elements;
-
-			if (!elements.color_1) {
-				cleanup();
-				reject(new Error('Target Practice did not report its color marker.'));
-				return;
+		if (target) {
+			try {
+				await target.stop();
+			} catch (stopError) {
+				error.message += '\nshutdown error: ' + stopError.message;
 			}
-			if (options.interactive && !elements.button_1) {
-				cleanup();
-				reject(new Error('Target Practice did not report its interaction probe.'));
-				return;
-			}
-
-			let ready = waitForMarker(robot, elements.color_1, true);
-			if (options.interactive) {
-				ready = ready.then(() => waitForInteraction(robot, target, elements.button_1));
-			}
-
-			ready.then(() => {
-				cleanup();
-				resolve(session);
-			}, error => {
-				cleanup();
-				reject(error);
-			});
 		}
-
-		target.once('elements', handleElements);
-		target.once('error', handleError);
-	});
-}
-
-function stop(robot) {
-	if (activeSession === null) {
-		return Promise.resolve();
-	}
-
-	const session = activeSession;
-	const marker = session.elements && session.elements.color_1;
-
-	try {
-		targetpractice.stop();
-	} catch (error) {
-		activeSession = null;
-		return Promise.reject(error);
-	}
-
-	const closed = marker ? waitForMarker(robot, marker, false) : Promise.resolve();
-	return closed.then(() => {
-		activeSession = null;
-	}, error => {
-		activeSession = null;
 		throw error;
-	});
+	}
 }
 
 module.exports = {
 	TARGET_COLOR: TARGET_COLOR,
-	start: start,
-	stop: stop
+	start: start
 };

--- a/test/integration/keyboard.js
+++ b/test/integration/keyboard.js
@@ -1,20 +1,30 @@
 /* jshint esversion: 6 */
 var robot = require('../..');
-var targetpractice = require('targetpractice/index.js');
+var targetFixture = require('../helpers/targetpractice');
 
 robot.setMouseDelay(100);
+robot.setKeyboardDelay(100);
 
 var target, elements;
 var originalTimeout;
+const macOSIt = process.platform === 'darwin' ? it : xit;
+const TYPING_TIMEOUT_MS = 5000;
 
 function expectNextTypedText(expected, done, next) {
+	let lastText;
+	let timer;
 	const handleType = element => {
 		if (element.id !== 'input_1') {
 			return;
 		}
 
+		lastText = element.text;
+		if (lastText !== expected) {
+			return;
+		}
+
+		clearTimeout(timer);
 		target.removeListener('type', handleType);
-		expect(element.text).toEqual(expected);
 		if (next) {
 			next();
 		} else {
@@ -22,6 +32,13 @@ function expectNextTypedText(expected, done, next) {
 		}
 	};
 
+	timer = setTimeout(() => {
+		target.removeListener('type', handleType);
+		done.fail(new Error(
+			'Timed out after ' + TYPING_TIMEOUT_MS + 'ms waiting for input_1 to contain ' +
+			JSON.stringify(expected) + '; last text was ' + JSON.stringify(lastText) + '.'
+		));
+	}, TYPING_TIMEOUT_MS);
 	target.on('type', handleType);
 }
 
@@ -35,17 +52,18 @@ describe('Integration/Keyboard', () => {
 		jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
 	});
 
-	beforeEach(done => {
-		target = targetpractice.start();
-		target.once('elements', message => {
-			elements = message;
-			done();
+	beforeEach(() => {
+		return targetFixture.start(robot, { interactive: true }).then(session => {
+			target = session.target;
+			elements = session.elements;
 		});
 	});
 
 	afterEach(() => {
-		targetpractice.stop();
-		target = null;
+		return targetFixture.stop(robot).then(() => {
+			target = null;
+			elements = null;
+		});
 	});
 
 	it('types', done => {
@@ -70,11 +88,7 @@ describe('Integration/Keyboard', () => {
 		robot.typeString(stringToType);
 	});
 
-	it('replaces selected input with a command-modified key tap on macOS', done => {
-		if (process.platform !== 'darwin') {
-			pending('macOS only: verifies command-modified keyboard events.');
-			return;
-		}
+	macOSIt('replaces selected input with a command-modified key tap on macOS', done => {
 
 		const initial = 'initial content';
 		const replacement = 'replacement content';
@@ -90,11 +104,7 @@ describe('Integration/Keyboard', () => {
 		robot.typeString(initial);
 	});
 
-	it('types a non-ASCII character with unicodeTap on macOS', done => {
-		if (process.platform !== 'darwin') {
-			pending('macOS only: verifies Unicode keyboard events.');
-			return;
-		}
+	macOSIt('types a non-ASCII character with unicodeTap on macOS', done => {
 
 		const marker = 'x';
 		const character = '嗨';

--- a/test/integration/keyboard.js
+++ b/test/integration/keyboard.js
@@ -95,7 +95,9 @@ describe('Integration/Keyboard', () => {
 		expectNextTypedText(initial, done, () => {
 			expectNextTypedText(replacement, done);
 			robot.keyTap('a', 'command');
-			robot.typeString(replacement);
+			// This test covers the shortcut; pace the replacement so a busy macOS
+			// runner does not drop queued text events.
+			robot.typeStringDelayed(replacement, 600);
 		});
 
 		const input_1 = elements.input_1;

--- a/test/integration/keyboard.js
+++ b/test/integration/keyboard.js
@@ -54,21 +54,21 @@ describe('Integration/Keyboard', () => {
 
 	beforeEach(() => {
 		return targetFixture.start(robot, { interactive: true }).then(session => {
-			target = session.target;
+			target = session;
 			elements = session.elements;
 		});
 	});
 
 	afterEach(() => {
-		return targetFixture.stop(robot).then(() => {
-			target = null;
-			elements = null;
-		});
+		const currentTarget = target;
+		target = null;
+		elements = null;
+		return currentTarget ? currentTarget.stop() : Promise.resolve();
 	});
 
 	it('types', done => {
 		const stringToType = 'hello world';
-		// Target Practice emits after the user has stopped typing.
+		// Target Practice emits every input state; wait for the final value.
 		expectNextTypedText(stringToType, done);
 
 		const input_1 = elements.input_1;

--- a/test/integration/mouse.js
+++ b/test/integration/mouse.js
@@ -19,16 +19,16 @@ describe('Integration/Mouse', () => {
 
 	beforeEach(() => {
 		return targetFixture.start(robot, { interactive: true }).then(session => {
-			target = session.target;
+			target = session;
 			elements = session.elements;
 		});
 	});
 
 	afterEach(() => {
-		return targetFixture.stop(robot).then(() => {
-			target = null;
-			elements = null;
-		});
+		const currentTarget = target;
+		target = null;
+		elements = null;
+		return currentTarget ? currentTarget.stop() : Promise.resolve();
 	});
 
 	it('clicks', done => {

--- a/test/integration/mouse.js
+++ b/test/integration/mouse.js
@@ -1,6 +1,6 @@
 /* jshint esversion: 6 */
 var robot = require('../..');
-var targetpractice = require('targetpractice/index.js');
+var targetFixture = require('../helpers/targetpractice');
 
 robot.setMouseDelay(100);
 
@@ -17,17 +17,18 @@ describe('Integration/Mouse', () => {
 		jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
 	});
 
-	beforeEach(done => {
-		target = targetpractice.start();
-		target.once('elements', message => {
-			elements = message;
-			done();
+	beforeEach(() => {
+		return targetFixture.start(robot, { interactive: true }).then(session => {
+			target = session.target;
+			elements = session.elements;
 		});
 	});
 
 	afterEach(() => {
-		targetpractice.stop();
-		target = null;
+		return targetFixture.stop(robot).then(() => {
+			target = null;
+			elements = null;
+		});
 	});
 
 	it('clicks', done => {

--- a/test/integration/screen.js
+++ b/test/integration/screen.js
@@ -1,47 +1,10 @@
 /* jshint esversion: 6 */
 var robot = require('../..');
-var targetpractice = require('targetpractice/index.js');
-var elements, target, readinessTimer;
+var targetFixture = require('../helpers/targetpractice');
+var elements, target;
 var originalTimeout;
-const TARGET_COLOR = 'c0ff33';
+const TARGET_COLOR = targetFixture.TARGET_COLOR;
 const TARGET_LOGICAL_SIZE = 50;
-const TARGET_READY_TIMEOUT_MS = 5000;
-const TARGET_POLL_INTERVAL_MS = 25;
-
-function waitForTargetPixel(done) {
-	const point = elements.color_1;
-	const deadline = Date.now() + TARGET_READY_TIMEOUT_MS;
-	let lastColor;
-
-	function poll() {
-		readinessTimer = null;
-
-		try {
-			lastColor = robot.getPixelColor(point.x, point.y);
-		} catch (error) {
-			done.fail(error);
-			return;
-		}
-
-		if (lastColor === TARGET_COLOR) {
-			done();
-			return;
-		}
-
-		if (Date.now() >= deadline) {
-			done.fail(new Error(
-				'Timed out after ' + TARGET_READY_TIMEOUT_MS +
-				'ms waiting for Target Practice pixel at (' + point.x + ', ' + point.y +
-				') to be painted ' + TARGET_COLOR + '; last color was ' + lastColor + '.'
-			));
-			return;
-		}
-
-		readinessTimer = setTimeout(poll, TARGET_POLL_INTERVAL_MS);
-	}
-
-	poll();
-}
 
 describe('Integration/Screen', () => {
 	beforeAll(() => {
@@ -53,23 +16,18 @@ describe('Integration/Screen', () => {
 		jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
 	});
 
-	beforeEach(done => {
-		readinessTimer = null;
-		target = targetpractice.start();
-		target.once('elements', message => {
-			elements = message;
-			waitForTargetPixel(done);
+	beforeEach(() => {
+		return targetFixture.start(robot).then(session => {
+			target = session.target;
+			elements = session.elements;
 		});
 	});
 
 	afterEach(() => {
-		if (readinessTimer !== null) {
-			clearTimeout(readinessTimer);
-			readinessTimer = null;
-		}
-		targetpractice.stop();
-		target = null;
-		elements = null;
+		return targetFixture.stop(robot).then(() => {
+			target = null;
+			elements = null;
+		});
 	});
 
 	it('reads a pixel color', () => {

--- a/test/integration/screen.js
+++ b/test/integration/screen.js
@@ -18,16 +18,16 @@ describe('Integration/Screen', () => {
 
 	beforeEach(() => {
 		return targetFixture.start(robot).then(session => {
-			target = session.target;
+			target = session;
 			elements = session.elements;
 		});
 	});
 
 	afterEach(() => {
-		return targetFixture.stop(robot).then(() => {
-			target = null;
-			elements = null;
-		});
+		const currentTarget = target;
+		target = null;
+		elements = null;
+		return currentTarget ? currentTarget.stop() : Promise.resolve();
 	});
 
 	it('reads a pixel color', () => {


### PR DESCRIPTION
Stabilizes desktop integration tests using merged Target Practice 0.0.8 ([PR #1](https://github.com/octalmage/targetpractice/pull/1)).

- Use `require('targetpractice')` and its awaited lifecycle.
- Verify physical visibility and an acknowledged probe click.
- Wait for exact input state and pace the macOS shortcut replacement.
- Skip unnecessary platform-specific fixture launches.

Verification: 75 local specs and all 10 CI jobs pass.