### PR TITLE
fix: stabilize cross-platform keyboard input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * fix: Normalize smooth mouse movement timing on Windows.
 * fix: Write the complete BMP file size in serialized headers.
 * test: Adopt Target Practice 0.0.8 lifecycle and verify fixture visibility and interactivity.
+* fix: Pace `typeString` with the configured keyboard delay and inject Unicode through scoped X11 keycode mappings.
+* test: Exercise select-all shortcuts and Unicode keyboard input across platforms.
 
 
 ## 0.8.0 (2026-07-19)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "jasmine": "^2.99.0",
         "node-gyp": "^12.2.0",
         "prebuild": "^13",
-        "targetpractice": "github:octalmage/targetpractice"
+        "targetpractice": "github:octalmage/targetpractice#413a2dfbd7898ce8c53dce5fb9b0fbbf68f37f32"
       }
     },
     "node_modules/@electron/get": {
@@ -5139,7 +5139,8 @@
     },
     "node_modules/targetpractice": {
       "version": "0.0.8",
-      "resolved": "git+ssh://git@github.com/octalmage/targetpractice.git#b1344fe9793402f992aa92cdfd5c777b8a4c79ea",
+      "resolved": "git+ssh://git@github.com/octalmage/targetpractice.git#413a2dfbd7898ce8c53dce5fb9b0fbbf68f37f32",
+      "integrity": "sha512-QBqdA5RL+Y71ewOEMaWWjBR9aWpx5BJ0ABxjb7VRlHjcDmIUOWRxDxQ0eLUzd/18D5jrxDbBtW6mCehAaeHiQg==",
       "dev": true,
       "dependencies": {
         "electron": "^35.7.5"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "jasmine": "^2.99.0",
     "node-gyp": "^12.2.0",
     "prebuild": "^13",
-    "targetpractice": "github:octalmage/targetpractice"
+    "targetpractice": "github:octalmage/targetpractice#413a2dfbd7898ce8c53dce5fb9b0fbbf68f37f32"
   }
 }

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -26,6 +26,7 @@
 		 XFlush(display))
 	#define X_KEY_EVENT_WAIT(display, key, is_press) \
 		(X_KEY_EVENT(display, key, is_press))
+	#define X_UNICODE_MAPPING_WAIT_MS 25
 #endif
 
 #if defined(IS_MACOSX)
@@ -331,13 +332,122 @@ void toggleUnicode(UniChar ch, const bool down)
 	#define toggleUniKey(c, down) toggleKey(c, down, MOD_NONE)
 #endif
 
+#if defined(USE_X11)
+
+static bool isModifierKeyCode(const XModifierKeymap *modifierMap,
+	                          const KeyCode keyCode)
+{
+	int index;
+
+	if (modifierMap == NULL) {
+		return false;
+	}
+
+	for (index = 0; index < 8 * modifierMap->max_keypermod; ++index) {
+		if (modifierMap->modifiermap[index] == keyCode) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static void tapUnicodeKey(const unsigned value)
+{
+	Display *display;
+	XModifierKeymap *modifierMap;
+	KeySym *mapping;
+	KeySym *scratchMapping = NULL;
+	KeyCode scratchKeyCode = 0;
+	char pressedKeys[32];
+	int minKeyCode;
+	int maxKeyCode;
+	int symbolsPerKeyCode;
+	int code;
+
+	if (value > 0x10FFFF || (value >= 0xD800 && value <= 0xDFFF)) {
+		return;
+	}
+
+	display = XGetMainDisplay();
+	XDisplayKeycodes(display, &minKeyCode, &maxKeyCode);
+	mapping = XGetKeyboardMapping(display, minKeyCode,
+	                              maxKeyCode - minKeyCode + 1,
+	                              &symbolsPerKeyCode);
+	if (mapping == NULL) {
+		return;
+	}
+	if (symbolsPerKeyCode <= 0) {
+		XFree(mapping);
+		return;
+	}
+
+	modifierMap = XGetModifierMapping(display);
+	XQueryKeymap(display, pressedKeys);
+
+	for (code = minKeyCode; code <= maxKeyCode; ++code) {
+		const int offset = (code - minKeyCode) * symbolsPerKeyCode;
+		int slot;
+
+		if (isModifierKeyCode(modifierMap, (KeyCode)code) ||
+		    ((unsigned char)pressedKeys[code / 8] & (1U << (code % 8)))) {
+			continue;
+		}
+
+		for (slot = 0; slot < symbolsPerKeyCode; ++slot) {
+			if (mapping[offset + slot] != NoSymbol) {
+				break;
+			}
+		}
+
+		if (slot == symbolsPerKeyCode) {
+			scratchKeyCode = (KeyCode)code;
+			scratchMapping = mapping + offset;
+			break;
+		}
+	}
+
+	if (modifierMap != NULL) {
+		XFreeModifiermap(modifierMap);
+	}
+	if (scratchKeyCode == 0) {
+		XFree(mapping);
+		return;
+	}
+
+	scratchMapping[0] = value >= 0x100
+		? (KeySym)(0x01000000U | value)
+		: (KeySym)value;
+	XChangeKeyboardMapping(display, scratchKeyCode, 1,
+	                       scratchMapping, 1);
+	XSync(display, False);
+
+	XTestFakeKeyEvent(display, scratchKeyCode, True, CurrentTime);
+	XTestFakeKeyEvent(display, scratchKeyCode, False, CurrentTime);
+	XSync(display, False);
+	/* Clients translate keycodes asynchronously. Keep the temporary mapping
+	 * available until they have consumed both key events. */
+	microsleep(X_UNICODE_MAPPING_WAIT_MS);
+
+	scratchMapping[0] = NoSymbol;
+	XChangeKeyboardMapping(display, scratchKeyCode, 1,
+	                       scratchMapping, 1);
+	XSync(display, False);
+	XFree(mapping);
+}
+#endif
+
 void unicodeTap(const unsigned value)
 {
 	#if defined(USE_X11)
-		char ch = (char)value;
+		if (value <= 0x7F) {
+			char ch = (char)value;
 
-		toggleUniKey(ch, true);
-		toggleUniKey(ch, false);
+			toggleUniKey(ch, true);
+			toggleUniKey(ch, false);
+		} else {
+			tapUnicodeKey(value);
+		}
 	#elif defined(IS_MACOSX)
 		UniChar ch = (UniChar)value; // Convert to unsigned char
 

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -680,7 +680,11 @@ Napi::Value typeStringWrapper(const Napi::CallbackInfo& info)
 
 		s = str.c_str();
 
-		typeStringDelayed(s, 0);
+		size_t cpm = keyboardDelay > 0 ? 60000 / keyboardDelay : 0;
+		if (keyboardDelay > 0 && cpm == 0) {
+			cpm = 1;
+		}
+		typeStringDelayed(s, cpm);
 
 		return Napi::Number::New(env, 1);
 	} else {

--- a/test/integration/keyboard.js
+++ b/test/integration/keyboard.js
@@ -7,8 +7,9 @@ robot.setKeyboardDelay(100);
 
 var target, elements;
 var originalTimeout;
-const macOSIt = process.platform === 'darwin' ? it : xit;
+const selectAllModifier = process.platform === 'darwin' ? 'command' : 'control';
 const TYPING_TIMEOUT_MS = 5000;
+const KEY_SEQUENCE_SETTLE_MS = 100;
 
 function expectNextTypedText(expected, done, next) {
 	let lastText;
@@ -88,15 +89,15 @@ describe('Integration/Keyboard', () => {
 		robot.typeString(stringToType);
 	});
 
-	macOSIt('replaces selected input with a command-modified key tap on macOS', done => {
+	it('replaces selected input with the platform select-all shortcut', done => {
 
 		const initial = 'initial content';
 		const replacement = 'replacement content';
 		expectNextTypedText(initial, done, () => {
 			expectNextTypedText(replacement, done);
-			robot.keyTap('a', 'command');
-			// This test covers the shortcut; pace the replacement so a busy macOS
-			// runner does not drop queued text events.
+			robot.keyTap('a', selectAllModifier);
+			// Pace the replacement so a busy runner does not drop queued text
+			// events while processing the shortcut.
 			robot.typeStringDelayed(replacement, 600);
 		});
 
@@ -106,12 +107,16 @@ describe('Integration/Keyboard', () => {
 		robot.typeString(initial);
 	});
 
-	macOSIt('types a non-ASCII character with unicodeTap on macOS', done => {
+	it('types a non-ASCII character with unicodeTap without changing the layout', done => {
 
 		const marker = 'x';
 		const character = '嗨';
+		const shiftedSymbols = '!@#$%^&*()_+{}|:"<>?';
 		expectNextTypedText(marker, done, () => {
-			expectNextTypedText(character, done);
+			expectNextTypedText(character, done, () => {
+				expectNextTypedText(character + shiftedSymbols, done);
+				setTimeout(() => robot.typeString(shiftedSymbols), KEY_SEQUENCE_SETTLE_MS);
+			});
 			robot.keyTap('backspace');
 			robot.unicodeTap(character.charCodeAt(0));
 		});


### PR DESCRIPTION
## Problem

`typeString` ignored the configured keyboard delay, allowing desktop clients to drop burst key events. Linux `unicodeTap` truncated non-ASCII values and could not type characters outside the active keyboard layout.

## Change

- Pace `typeString` using the configured keyboard delay.
- Inject non-ASCII Linux input through a scoped, unused X11 keycode mapping and restore it after delivery.
- Run select-all and Unicode integration contracts on every platform.

## Verification

- macOS: `npm test` — 75 specs, 0 failures.
- Linux / Node 25: `npm test` — 75 specs, 0 failures.
- Keyboard integration: 10 consecutive passes on macOS and Linux.