### PR TITLE
fix: pace typeString with keyboard delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * fix: Normalize smooth mouse movement timing on Windows.
 * fix: Write the complete BMP file size in serialized headers.
 * test: Adopt Target Practice 0.0.8 lifecycle and verify fixture visibility and interactivity.
+* fix: Pace `typeString` with the configured keyboard delay.
+* test: Exercise select-all shortcuts across platforms.
 
 
 ## 0.8.0 (2026-07-19)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "jasmine": "^2.99.0",
         "node-gyp": "^12.2.0",
         "prebuild": "^13",
-        "targetpractice": "github:octalmage/targetpractice"
+        "targetpractice": "github:octalmage/targetpractice#413a2dfbd7898ce8c53dce5fb9b0fbbf68f37f32"
       }
     },
     "node_modules/@electron/get": {
@@ -5139,7 +5139,8 @@
     },
     "node_modules/targetpractice": {
       "version": "0.0.8",
-      "resolved": "git+ssh://git@github.com/octalmage/targetpractice.git#b1344fe9793402f992aa92cdfd5c777b8a4c79ea",
+      "resolved": "git+ssh://git@github.com/octalmage/targetpractice.git#413a2dfbd7898ce8c53dce5fb9b0fbbf68f37f32",
+      "integrity": "sha512-QBqdA5RL+Y71ewOEMaWWjBR9aWpx5BJ0ABxjb7VRlHjcDmIUOWRxDxQ0eLUzd/18D5jrxDbBtW6mCehAaeHiQg==",
       "dev": true,
       "dependencies": {
         "electron": "^35.7.5"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "jasmine": "^2.99.0",
     "node-gyp": "^12.2.0",
     "prebuild": "^13",
-    "targetpractice": "github:octalmage/targetpractice"
+    "targetpractice": "github:octalmage/targetpractice#413a2dfbd7898ce8c53dce5fb9b0fbbf68f37f32"
   }
 }

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -680,7 +680,11 @@ Napi::Value typeStringWrapper(const Napi::CallbackInfo& info)
 
 		s = str.c_str();
 
-		typeStringDelayed(s, 0);
+		size_t cpm = keyboardDelay > 0 ? 60000 / keyboardDelay : 0;
+		if (keyboardDelay > 0 && cpm == 0) {
+			cpm = 1;
+		}
+		typeStringDelayed(s, cpm);
 
 		return Napi::Number::New(env, 1);
 	} else {

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -681,6 +681,7 @@ Napi::Value typeStringWrapper(const Napi::CallbackInfo& info)
 		s = str.c_str();
 
 		size_t cpm = keyboardDelay > 0 ? 60000 / keyboardDelay : 0;
+		// Don't let a positive keyboard delay round down to 0 CPM.
 		if (keyboardDelay > 0 && cpm == 0) {
 			cpm = 1;
 		}

--- a/test/integration/keyboard.js
+++ b/test/integration/keyboard.js
@@ -8,6 +8,7 @@ robot.setKeyboardDelay(100);
 var target, elements;
 var originalTimeout;
 const macOSIt = process.platform === 'darwin' ? it : xit;
+const selectAllModifier = process.platform === 'darwin' ? 'command' : 'control';
 const TYPING_TIMEOUT_MS = 5000;
 
 function expectNextTypedText(expected, done, next) {
@@ -88,15 +89,15 @@ describe('Integration/Keyboard', () => {
 		robot.typeString(stringToType);
 	});
 
-	macOSIt('replaces selected input with a command-modified key tap on macOS', done => {
+	it('replaces selected input with the platform select-all shortcut', done => {
 
 		const initial = 'initial content';
 		const replacement = 'replacement content';
 		expectNextTypedText(initial, done, () => {
 			expectNextTypedText(replacement, done);
-			robot.keyTap('a', 'command');
-			// This test covers the shortcut; pace the replacement so a busy macOS
-			// runner does not drop queued text events.
+			robot.keyTap('a', selectAllModifier);
+			// Pace the replacement so a busy runner does not drop queued text
+			// events while processing the shortcut.
 			robot.typeStringDelayed(replacement, 600);
 		});
 


### PR DESCRIPTION
## Problem

`typeString` ignored the configured keyboard delay, allowing desktop clients to drop burst key events. Linux integration coverage also depended on an unpinned Target Practice revision.

## Change

- Pace `typeString` using the configured keyboard delay.
- Exercise select-all with each platform's modifier.
- Pin Target Practice to its Linux Xvfb readiness fix.

## Verification

- `npm install`
- `npx jasmine test/integration/keyboard.js` — 5 specs, 0 failures.