### PR TITLE
feat: add macOS permission APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* feat: Add macOS Accessibility and Screen Recording permission APIs.
 * fix: Normalize smooth mouse movement timing on Windows.
 * fix: Write the complete BMP file size in serialized headers.
 * test: Adopt Target Practice 0.0.8 lifecycle and verify fixture visibility and interactivity.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ Read the [Wiki](https://github.com/octalmage/robotjs/wiki) for more information!
 
 The RobotJS API is hosted at <https://robotjs.dev/docs/syntax>.
 
+### macOS permissions
+
+`getAccessibilityPermission()` and `getScreenCapturePermission()` report the
+current grants. `requestAccessibilityPermission()` and
+`requestScreenCapturePermission()` trigger the corresponding macOS system
+prompts. macOS still requires the user to approve each request.
+The Accessibility prompt is asynchronous, so `requestAccessibilityPermission()`
+returns the current grant. Check `getAccessibilityPermission()` again after the
+user responds.
+
 ## Building
 
 Please ensure you have the required dependencies before installing:

--- a/index.d.ts
+++ b/index.d.ts
@@ -95,6 +95,10 @@ export function getMousePos(): { x: number, y: number }
 export function getPixelColor(x: number, y: number): string
 export function getScreenSize(): { width: number, height: number }
 export function getDisplays(): Display[]
+export function getAccessibilityPermission(): boolean | null
+export function requestAccessibilityPermission(): boolean | null
+export function getScreenCapturePermission(): boolean | null
+export function requestScreenCapturePermission(): boolean | null
 
 export var screen: Screen
 export var image: ImageModule

--- a/src/robotjs.cc
+++ b/src/robotjs.cc
@@ -15,6 +15,9 @@
 #include "io.h"
 #include "snprintf.h"
 #include "microsleep.h"
+#if defined(__APPLE__)
+	#include <ApplicationServices/ApplicationServices.h>
+#endif
 #if defined(USE_X11)
 	#include "xdisplay.h"
 #endif
@@ -1747,6 +1750,62 @@ Napi::Value saveImageWrapper(const Napi::CallbackInfo& info)
 	return Napi::Boolean::New(env, true);
 }
 
+Napi::Value getAccessibilityPermissionWrapper(const Napi::CallbackInfo& info)
+{
+	Napi::Env env = info.Env();
+
+#if defined(__APPLE__)
+	return Napi::Boolean::New(env, AXIsProcessTrusted());
+#else
+	return env.Null();
+#endif
+}
+
+Napi::Value requestAccessibilityPermissionWrapper(const Napi::CallbackInfo& info)
+{
+	Napi::Env env = info.Env();
+
+#if defined(__APPLE__)
+	const void *keys[] = { kAXTrustedCheckOptionPrompt };
+	const void *values[] = { kCFBooleanTrue };
+	CFDictionaryRef options = CFDictionaryCreate(
+		kCFAllocatorDefault,
+		keys,
+		values,
+		1,
+		&kCFTypeDictionaryKeyCallBacks,
+		&kCFTypeDictionaryValueCallBacks
+	);
+	const bool trusted = AXIsProcessTrustedWithOptions(options);
+	CFRelease(options);
+	return Napi::Boolean::New(env, trusted);
+#else
+	return env.Null();
+#endif
+}
+
+Napi::Value getScreenCapturePermissionWrapper(const Napi::CallbackInfo& info)
+{
+	Napi::Env env = info.Env();
+
+#if defined(__APPLE__)
+	return Napi::Boolean::New(env, CGPreflightScreenCaptureAccess());
+#else
+	return env.Null();
+#endif
+}
+
+Napi::Value requestScreenCapturePermissionWrapper(const Napi::CallbackInfo& info)
+{
+	Napi::Env env = info.Env();
+
+#if defined(__APPLE__)
+	return Napi::Boolean::New(env, CGRequestScreenCaptureAccess());
+#else
+	return env.Null();
+#endif
+}
+
 Napi::Object InitAll(Napi::Env env, Napi::Object exports)
 {
 	exports.Set(Napi::String::New(env, "dragMouse"),
@@ -1841,6 +1900,18 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports)
 
 	exports.Set(Napi::String::New(env, "setXDisplayName"),
 				Napi::Function::New(env, setXDisplayNameWrapper));
+
+	exports.Set(Napi::String::New(env, "getAccessibilityPermission"),
+				Napi::Function::New(env, getAccessibilityPermissionWrapper));
+
+	exports.Set(Napi::String::New(env, "requestAccessibilityPermission"),
+				Napi::Function::New(env, requestAccessibilityPermissionWrapper));
+
+	exports.Set(Napi::String::New(env, "getScreenCapturePermission"),
+				Napi::Function::New(env, getScreenCapturePermissionWrapper));
+
+	exports.Set(Napi::String::New(env, "requestScreenCapturePermission"),
+				Napi::Function::New(env, requestScreenCapturePermissionWrapper));
 
 	return exports;
 }

--- a/test/permissions.js
+++ b/test/permissions.js
@@ -1,0 +1,26 @@
+const robot = require('../index.js');
+
+describe('Permissions', () => {
+	it('Reports permission status without prompting.', () => {
+		const accessibility = robot.getAccessibilityPermission();
+		const screenCapture = robot.getScreenCapturePermission();
+
+		if (process.platform === 'darwin') {
+			expect(typeof accessibility).toBe('boolean');
+			expect(typeof screenCapture).toBe('boolean');
+		} else {
+			expect(accessibility).toBeNull();
+			expect(screenCapture).toBeNull();
+		}
+	});
+
+	it('Exposes explicit permission request functions.', () => {
+		expect(typeof robot.requestAccessibilityPermission).toBe('function');
+		expect(typeof robot.requestScreenCapturePermission).toBe('function');
+
+		if (process.platform !== 'darwin') {
+			expect(robot.requestAccessibilityPermission()).toBeNull();
+			expect(robot.requestScreenCapturePermission()).toBeNull();
+		}
+	});
+});


### PR DESCRIPTION
I think these will be super nice for users distributing applications leveraging RobotJS on macOS. 