### PR TITLE
mac: switch to universal prebuilds

### DIFF
--- a/.github/workflows/prebuilds.yml
+++ b/.github/workflows/prebuilds.yml
@@ -100,13 +100,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: macOS x64
-            artifact: darwin-x64
-            os: macos-15-intel
-            architecture: x64
-            deployment-target: "10.15"
           - name: macOS arm64
-            artifact: darwin-arm64
+            artifact: darwin-x64+arm64
             os: macos-15
             architecture: arm64
             deployment-target: "11.0"
@@ -150,7 +145,7 @@ jobs:
           tar -xf "$archive" -C "$RUNNER_TEMP"
           cd "$RUNNER_TEMP/libpng-$LIBPNG_VERSION"
           export MACOSX_DEPLOYMENT_TARGET="${{ matrix.deployment-target }}"
-          ./configure --prefix="$prefix" --disable-shared --enable-static
+          ./configure --prefix="$prefix" --disable-shared --enable-static CFLAGS="-arch x86_64 -arch arm64"
           make -j"$(sysctl -n hw.ncpu)"
           make install
           echo "PKG_CONFIG_PATH=$prefix/lib/pkgconfig" >> "$GITHUB_ENV"
@@ -160,7 +155,12 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Build N-API prebuild
+        if: runner.os != 'macOS'
         run: npm run build:prebuild
+
+      - name: Build N-API prebuild
+        if: runner.os == 'macOS'
+        run: npm run build:prebuild-universal
 
       - name: Test prebuild on Node.js 24
         env:

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,6 +11,14 @@
       'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
         'CLANG_CXX_LIBRARY': 'libc++',
         'MACOSX_DEPLOYMENT_TARGET': '10.15',
+        'OTHER_CFLAGS': [
+          '-arch x86_64',
+          '-arch arm64'
+        ],
+        'OTHER_LDFLAGS': [
+          '-arch x86_64',
+          '-arch arm64'
+        ]
       },
       'msvs_settings': {
         'VCCLCompilerTool': { 'ExceptionHandling': 1 },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "jasmine \"test/**/*.js\"",
     "install": "node-gyp-build",
     "build:prebuild": "prebuildify --napi --name node.napi --strip",
+    "build:prebuild-universal": "prebuildify --napi --name node.napi --strip --arch x64+arm64",
     "verify-prebuilds": "node scripts/verify-prebuilds.js",
     "prepack": "npm run verify-prebuilds",
     "build": "node-gyp rebuild"

--- a/scripts/verify-prebuilds.js
+++ b/scripts/verify-prebuilds.js
@@ -4,8 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const expected = [
-    'darwin-arm64/node.napi.node',
-    'darwin-x64/node.napi.node',
+    'darwin-x64+arm64/node.napi.node',
     'linux-arm64/node.napi.glibc.node',
     'linux-x64/node.napi.glibc.node',
     'win32-arm64/node.napi.node',


### PR DESCRIPTION
First of all: Thanks for the great work, @octalmage
Great to see prebuilds via NAPI and prebuildify, I hope I can contribute a little on the mac side.

This PR builds the macos prebuilds as universal binaries so that they can be easily consumed in universal applications downstream

I tested this via https://github.com/csett86/robotjs/ and a long-standing friendly fork https://github.com/jitsi/robotjs