### PR TITLE
Fix build error in xdisplay.c

### DIFF
--- a/src/xdisplay.c
+++ b/src/xdisplay.c
@@ -1,6 +1,7 @@
 #include "xdisplay.h"
 #include <stdio.h> /* For fputs() */
 #include <stdlib.h> /* For atexit() */
+#include <string.h> /* For strdup() */
 
 static Display *mainDisplay = NULL;
 static int registered = 0;


### PR DESCRIPTION
```
  CC(target) Release/obj.target/robotjs/src/xdisplay.o
../src/xdisplay.c: In function ‘setXDisplay’:
../src/xdisplay.c:53:23: error: implicit declaration of function ‘strdup’ [-Wimplicit-function-declaration]
   53 |         displayName = strdup(name);
      |                       ^~~~~~
../src/xdisplay.c:53:23: warning: incompatible implicit declaration of built-in function ‘strdup’ [-Wbuiltin-declaration-mismatch]
make: *** [robotjs.target.mk:143: Release/obj.target/robotjs/src/xdisplay.o] Error 1
```